### PR TITLE
Rainforest Fixes

### DIFF
--- a/Assets/Python/Barbs.py
+++ b/Assets/Python/Barbs.py
@@ -530,7 +530,7 @@ class Barbs:
 			for y in range(tTL[1], tBR[1]+1):
 				plot = gc.getMap().plot(x,y)
 				if plot.isHills() or plot.isFlatlands():
-					if plot.getTerrainType() != con.iMarsh and (bJungle or plot.getFeatureType() != con.iJungle):
+					if plot.getTerrainType() != con.iMarsh and (bJungle or plot.getFeatureType() != con.iJungle) and (plot.getFeatureType() != con.iRainforest):
 						if not plot.isUnit() and not plot.isCity():
 							bClear = True
 							for i in range(x-1, x+2):

--- a/Assets/Python/CvRFCEventHandler.py
+++ b/Assets/Python/CvRFCEventHandler.py
@@ -631,6 +631,7 @@ class CvRFCEventHandler:
 			
 			if iFeature == con.iForest: iGold = 15
 			elif iFeature == con.iJungle: iGold = 20
+			elif iFeature == con.iRainforest: iGold = 20
 			
 			if iGold > 0:
 				gc.getPlayer(con.iBrazil).changeGold(iGold)

--- a/Assets/Python/RFCUtils.py
+++ b/Assets/Python/RFCUtils.py
@@ -826,7 +826,7 @@ class RFCUtils:
                 bContinue = True
                 pCurrent = gc.getMap().plot( tCoords[0], tCoords[1] )
                 if ( pCurrent.isHills() or pCurrent.isFlatlands() ):
-                        if (pCurrent.getTerrainType() != con.iMarsh) and (pCurrent.getFeatureType() != con.iJungle):
+                        if (pCurrent.getTerrainType() != con.iMarsh) and (pCurrent.getFeatureType() != con.iJungle) and (pCurrent.getFeatureType() != con.iRainforest):
                                 if ( not pCurrent.isCity() and not pCurrent.isUnit() ):
                                         if (pCurrent.countTotalCulture() == 0 ):
                                                 # this is a good plot, so paint it and continue search
@@ -904,7 +904,7 @@ class RFCUtils:
                 bContinue = True
                 pCurrent = gc.getMap().plot( tCoords[0], tCoords[1] )
                 if ( pCurrent.isHills() or pCurrent.isFlatlands() ):
-                        if (pCurrent.getTerrainType() != con.iMarsh) and (pCurrent.getFeatureType() != con.iJungle):
+                        if (pCurrent.getTerrainType() != con.iMarsh) and (pCurrent.getFeatureType() != con.iJungle) and (pCurrent.getFeatureType() != con.iRainforest):
                                 if ( not pCurrent.isCity() and not pCurrent.isUnit() ):
                                         iClean = 0
                                         for x in range(tCoords[0] - 1, tCoords[0] + 2):        # from x-1 to x+1
@@ -926,7 +926,7 @@ class RFCUtils:
                 bContinue = True
                 pCurrent = gc.getMap().plot( tCoords[0], tCoords[1] )
                 if ( pCurrent.isHills() or pCurrent.isFlatlands() ):
-                        if (pCurrent.getTerrainType() != con.iMarsh) and (pCurrent.getFeatureType() != con.iJungle):
+                        if (pCurrent.getTerrainType() != con.iMarsh) and (pCurrent.getFeatureType() != con.iJungle) and (pCurrent.getFeatureType() != con.iRainforest):
                                 if ( not pCurrent.isCity() and not pCurrent.isUnit() ):
                                         if (pCurrent.getOwner() in argsList ):
                                                 # this is a good plot, so paint it and continue search
@@ -940,7 +940,7 @@ class RFCUtils:
 		bContinue = True
 		pCurrent = gc.getMap().plot(tCoords[0], tCoords[1])
 		if pCurrent.isHills() or pCurrent.isFlatlands():
-			if pCurrent.getTerrainType() != con.iMarsh and pCurrent.getFeatureType() != con.iJungle:
+			if pCurrent.getTerrainType() != con.iMarsh and pCurrent.getFeatureType() != con.iJungle and pCurrent.getFeatureType() != con.iRainforest:
 				if not pCurrent.isCity() and not pCurrent.isUnit():
 					return (None, bPaint, bContinue)
 		return (None, not bPaint, bContinue)
@@ -952,7 +952,7 @@ class RFCUtils:
                 bContinue = True
                 pCurrent = gc.getMap().plot( tCoords[0], tCoords[1] )
                 if ( pCurrent.isHills() or pCurrent.isFlatlands() ):
-                        if (pCurrent.getTerrainType() != con.iMarsh) and (pCurrent.getFeatureType() != con.iJungle):
+                        if (pCurrent.getTerrainType() != con.iMarsh) and (pCurrent.getFeatureType() != con.iJungle) and (pCurrent.getFeatureType() != con.iRainforest):
                                 if ( not pCurrent.isCity() and not pCurrent.isUnit() ):
                                         iClean = 0
                                         for x in range(tCoords[0] - 1, tCoords[0] + 2):        # from x-1 to x+1
@@ -977,7 +977,7 @@ class RFCUtils:
                 if ( pCurrent.isHills() or pCurrent.isFlatlands() ):
                         if ( not pCurrent.isImpassable()):
                                 if ( not pCurrent.isUnit() ):
-                                        if (pCurrent.getTerrainType() != con.iDesert) and (pCurrent.getTerrainType() != con.iTundra) and (pCurrent.getTerrainType() != con.iMarsh) and (pCurrent.getFeatureType() != con.iJungle):
+                                        if (pCurrent.getTerrainType() != con.iDesert) and (pCurrent.getTerrainType() != con.iTundra) and (pCurrent.getTerrainType() != con.iMarsh) and (pCurrent.getFeatureType() != con.iJungle) and (pCurrent.getFeatureType() != con.iRainforest):
                                                 if (pCurrent.countTotalCulture() == 0 ):
                                                         # this is a good plot, so paint it and continue search
                                                         return (None, bPaint, bContinue)
@@ -1052,7 +1052,7 @@ class RFCUtils:
                 bContinue = True
                 pCurrent = gc.getMap().plot( tCoords[0], tCoords[1] )
                 if ( pCurrent.isHills() or pCurrent.isFlatlands() ):
-                        if (pCurrent.getTerrainType() != con.iMarsh) and (pCurrent.getFeatureType() != con.iJungle):
+                        if (pCurrent.getTerrainType() != con.iMarsh) and (pCurrent.getFeatureType() != con.iJungle) and (pCurrent.getFeatureType() != con.iRainforest):
                                 if ( not pCurrent.isCity() and not pCurrent.isUnit() ):
                                             if (pCurrent.getOwner() == argsList ):
                                                     # this is a good plot, so paint it and continue search
@@ -1459,8 +1459,8 @@ class RFCUtils:
 			for y in range(68):
 				plot = gc.getMap().plot(x, y)
 				if plot.getOwner() == iPlayer:
-					if plot.getImprovementType() == gc.getInfoTypeForString("IMPROVEMENT_SLAVE_PLANTATION"):
-						plot.setImprovementType(gc.getInfoTypeForString("IMPROVEMENT_PLANTATION"))
+					if plot.getImprovementType() == con.iSlavePlantation:
+						plot.setImprovementType(con.iPlantation)
 					if plot.isCity():
 						self.removeSlaves(plot.getPlotCity())
 						
@@ -1473,12 +1473,12 @@ class RFCUtils:
 			slave.kill(con.iBarbarian, False)
 			
 	def removeSlaves(self, city):
-		city.setFreeSpecialistCount(gc.getInfoTypeForString("SPECIALIST_SLAVE"), 0)
+		city.setFreeSpecialistCount(con.iSettledSlave, 0)
 		
 	def freeSlaves(self, city, iPlayer):
-		iNumSlaves = city.getFreeSpecialistCount(gc.getInfoTypeForString("SPECIALIST_SLAVE"))
+		iNumSlaves = city.getFreeSpecialistCount(con.iSettledSlave)
 		if iNumSlaves > 0:
-			city.setFreeSpecialistCount(gc.getInfoTypeForString("SPECIALIST_SLAVE"), 0)
+			city.setFreeSpecialistCount(con.iSettledSlave, 0)
 			self.makeUnit(gc.getUnitClassInfo(gc.getUnitInfo(con.iSlave).getUnitClassType()).getDefaultUnitIndex(), iPlayer, (city.getX(), city.getY()), iNumSlaves)
 		
 	def getRandomEntry(self, list):

--- a/Assets/XML/Units/CIV4BuildInfos.xml
+++ b/Assets/XML/Units/CIV4BuildInfos.xml
@@ -819,7 +819,7 @@
 		</BuildInfo>
 		<BuildInfo>
 			<Type>BUILD_DEFORESTATION</Type>
-			<Description>TXT_KEY_BUILD_DEFORESTATION</Description>
+			<Description>TXT_KEY_BUILD_REMOVE_JUNGLE</Description>
 			<Help/>
 			<PrereqTech>NONE</PrereqTech>
 			<iTime>0</iTime>
@@ -836,6 +836,27 @@
 					<iProduction>40</iProduction>
 					<bRemove>1</bRemove>
 				</FeatureStruct>
+			</FeatureStructs>
+			<HotKey>KB_C</HotKey>
+			<bAltDown>1</bAltDown>
+			<bShiftDown>0</bShiftDown>
+			<bCtrlDown>0</bCtrlDown>
+			<iHotKeyPriority>0</iHotKeyPriority>
+			<Button>,Art/Interface/Buttons/Builds/BuildChopDown.dds,Art/Interface/Buttons/Actions_Builds_LeaderHeads_Specialists_Atlas.dds,7,8</Button>
+			<bGraphicalOnly>1</bGraphicalOnly>
+		</BuildInfo>
+		<BuildInfo>
+			<Type>BUILD_DEFORESTATION_RAINFOREST</Type>
+			<Description>TXT_KEY_BUILD_REMOVE_RAINFOREST</Description>
+			<Help/>
+			<PrereqTech>NONE</PrereqTech>
+			<iTime>0</iTime>
+			<iCost>0</iCost>
+			<bKill>0</bKill>
+			<ImprovementType>NONE</ImprovementType>
+			<RouteType>NONE</RouteType>
+			<EntityEvent>ENTITY_EVENT_CHOP</EntityEvent>
+			<FeatureStructs>
 				<FeatureStruct>
 					<FeatureType>FEATURE_RAINFOREST</FeatureType>
 					<PrereqTech>TECH_BIOLOGY</PrereqTech>

--- a/Assets/XML/Units/CIV4BuildInfos.xml
+++ b/Assets/XML/Units/CIV4BuildInfos.xml
@@ -11,7 +11,6 @@
 			<Description>TXT_KEY_BUILD_ROAD</Description>
 			<Help/>
 			<PrereqTech>TECH_THE_WHEEL</PrereqTech>
-			<!-- Rhye -->
 			<iTime>300</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -28,10 +27,9 @@
 		</BuildInfo>
 		<BuildInfo>
 			<Type>BUILD_ROMAN_ROAD</Type>
-			<Description>TXT_KEY_BUILD_ROAD</Description>
+			<Description>TXT_KEY_BUILD_ROMAN_ROAD</Description>
 			<Help/>
 			<PrereqTech>TECH_THE_WHEEL</PrereqTech>
-			<!-- Rhye -->
 			<iTime>300</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -52,7 +50,6 @@
 			<Description>TXT_KEY_BUILD_RAILROAD</Description>
 			<Help/>
 			<PrereqTech>TECH_RAILROAD</PrereqTech>
-			<!-- Rhye -->
 			<iTime>400</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -72,7 +69,6 @@
 			<Description>TXT_KEY_BUILD_FARM</Description>
 			<Help/>
 			<PrereqTech>TECH_AGRICULTURE</PrereqTech>
-			<!-- Rhye -->
 			<iTime>600</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -178,7 +174,6 @@
 			<Description>TXT_KEY_BUILD_MINE</Description>
 			<Help/>
 			<PrereqTech>TECH_MINING</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>500</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -261,7 +256,6 @@
 			<Description>TXT_KEY_BUILD_LUMBERMILL</Description>
 			<Help/>
 			<PrereqTech>TECH_GUILDS</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>900</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -281,7 +275,6 @@
 			<Description>TXT_KEY_BUILD_WINDMILL</Description>
 			<Help/>
 			<PrereqTech>TECH_MACHINERY</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>600</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -323,7 +316,6 @@
 			<Description>TXT_KEY_BUILD_WATERMILL</Description>
 			<Help/>
 			<PrereqTech>TECH_MACHINERY</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>900</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -406,7 +398,6 @@
 			<Description>TXT_KEY_BUILD_SLAVE_PLANTATION</Description>
 			<Help/>
 			<PrereqTech>TECH_CALENDAR</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>0</iTime>
 			<iCost>0</iCost>
 			<bKill>1</bKill>
@@ -516,7 +507,6 @@
 			<Description>TXT_KEY_BUILD_CAMP</Description>
 			<Help/>
 			<PrereqTech>TECH_HUNTING</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>500</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -596,7 +586,6 @@
 			<Description>TXT_KEY_BUILD_WINERY</Description>
 			<Help/>
 			<PrereqTech>TECH_MONARCHY</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>600</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -638,7 +627,6 @@
 			<Description>TXT_KEY_BUILD_COTTAGE</Description>
 			<Help/>
 			<PrereqTech>TECH_POTTERY</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>700</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -721,6 +709,26 @@
 					<iProduction>0</iProduction>
 					<bRemove>1</bRemove>
 				</FeatureStruct>
+			</FeatureStructs>
+			<HotKey>KB_C</HotKey>
+			<bAltDown>1</bAltDown>
+			<bShiftDown>0</bShiftDown>
+			<bCtrlDown>0</bCtrlDown>
+			<iHotKeyPriority>0</iHotKeyPriority>
+			<Button>,Art/Interface/Buttons/Builds/BuildChopDown.dds,Art/Interface/Buttons/Actions_Builds_LeaderHeads_Specialists_Atlas.dds,7,8</Button>
+		</BuildInfo>
+		<BuildInfo>
+			<Type>BUILD_REMOVE_RAINFOREST</Type>
+			<Description>TXT_KEY_BUILD_REMOVE_RAINFOREST</Description>
+			<Help/>
+			<PrereqTech>NONE</PrereqTech>
+			<iTime>0</iTime>
+			<iCost>0</iCost>
+			<bKill>0</bKill>
+			<ImprovementType>NONE</ImprovementType>
+			<RouteType>NONE</RouteType>
+			<EntityEvent>ENTITY_EVENT_CHOP</EntityEvent>
+			<FeatureStructs>
 				<FeatureStruct>
 					<FeatureType>FEATURE_RAINFOREST</FeatureType>
 					<PrereqTech>TECH_BIOLOGY</PrereqTech>
@@ -849,7 +857,6 @@
 			<Description>TXT_KEY_BUILD_FARM</Description>
 			<Help/>
 			<PrereqTech>TECH_AGRICULTURE</PrereqTech>
-			<!-- Rhye -->
 			<iTime>600</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -879,13 +886,11 @@
 					<bRemove>1</bRemove>
 				</FeatureStruct>
 				<FeatureStruct>
-					<!-- Rhye - start -->
 					<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 					<PrereqTech>TECH_BIOLOGY</PrereqTech>
 					<iTime>500</iTime>
 					<iProduction>0</iProduction>
 					<bRemove>0</bRemove>
-					<!-- Rhye - end -->
 				</FeatureStruct>
 			</FeatureStructs>
 			<HotKey>KB_I</HotKey>
@@ -901,7 +906,6 @@
 			<Description>TXT_KEY_BUILD_MINE</Description>
 			<Help/>
 			<PrereqTech>TECH_MINING</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>500</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -986,7 +990,6 @@
 			<Description>TXT_KEY_BUILD_WINDMILL</Description>
 			<Help/>
 			<PrereqTech>TECH_MACHINERY</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>600</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -1029,7 +1032,6 @@
 			<Description>TXT_KEY_BUILD_WATERMILL</Description>
 			<Help/>
 			<PrereqTech>TECH_MACHINERY</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>900</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -1072,7 +1074,6 @@
 			<Description>TXT_KEY_BUILD_PLANTATION</Description>
 			<Help/>
 			<PrereqTech>TECH_CALENDAR</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>700</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -1157,7 +1158,6 @@
 			<Description>TXT_KEY_BUILD_PASTURE</Description>
 			<Help/>
 			<PrereqTech>TECH_ANIMAL_HUSBANDRY</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>500</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -1242,7 +1242,6 @@
 			<Description>TXT_KEY_BUILD_WINERY</Description>
 			<Help/>
 			<PrereqTech>TECH_MONARCHY</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>600</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>
@@ -1285,7 +1284,6 @@
 			<Description>TXT_KEY_BUILD_COTTAGE</Description>
 			<Help/>
 			<PrereqTech>TECH_POTTERY</PrereqTech>
-			<!-- Rhye  -->
 			<iTime>700</iTime>
 			<iCost>0</iCost>
 			<bKill>0</bKill>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -1206,6 +1206,10 @@
 					<bBuild>1</bBuild>
 				</Build>
 				<Build>
+					<BuildType>BUILD_REMOVE_RAINFOREST</BuildType>
+					<bBuild>1</bBuild>
+				</Build>
+				<Build>
 					<BuildType>BUILD_REMOVE_FOREST</BuildType>
 					<bBuild>1</bBuild>
 				</Build>
@@ -1458,6 +1462,10 @@
 				</Build>
 				<Build>
 					<BuildType>BUILD_DEFORESTATION</BuildType>
+					<bBuild>1</bBuild>
+				</Build>
+				<Build>
+					<BuildType>BUILD_DEFORESTATION_RAINFOREST</BuildType>
 					<bBuild>1</bBuild>
 				</Build>
 				<Build>
@@ -1720,6 +1728,10 @@
 				</Build>
 				<Build>
 					<BuildType>BUILD_REMOVE_JUNGLE</BuildType>
+					<bBuild>1</bBuild>
+				</Build>
+				<Build>
+					<BuildType>BUILD_REMOVE_RAINFOREST</BuildType>
 					<bBuild>1</bBuild>
 				</Build>
 				<Build>


### PR DESCRIPTION
You have to merge the text key changes before you merge this. Most of these branches I am uploading are interconnected so take care when you merge them.

Barbs.py:           Added Rainforest to the preventing barbarian spawn list (along with Jungle and Marsh)

CvRFCEventHandler.py:       Made Rainforest give gold for the Brazilian Unique Unit (along with Jungle and Forest)

RFCUtils.py:            Added Rainforest to the preventing barbarian spawn list (along with Jungle and Marsh)
                Changed some gc.getInfoTypeForString to Constants

CIV4BuildInfos.xml:     Corrected Text Keys
                Removed Rhye Notes
                Adds a seperate Remove Rainforest build so that when you try to remove rainforest the text says "Remove Rainforest" instead of "Remove Jungle".
