### PR TITLE
Python to Scenario File

### DIFF
--- a/Assets/Python/RiseAndFall.py
+++ b/Assets/Python/RiseAndFall.py
@@ -457,12 +457,12 @@ class RiseAndFall:
 		if utils.getScenario() == i600AD:
 			Civilizations.initScenarioTechs(i600AD)
 			self.create600ADstartingUnits()
-			self.assign600ADGold()
+#			self.assign600ADGold()
 			
 		if utils.getScenario() == i1700AD:
 			Civilizations.initScenarioTechs(i1700AD)
 			self.create1700ADstartingUnits()
-			self.assign1700ADGold()
+#			self.assign1700ADGold()
 			self.init1700ADDiplomacy()
 			self.prepareColonists()
 			self.adjust1700ADCulture()
@@ -472,7 +472,7 @@ class RiseAndFall:
 			
 			pChina.updateTradeRoutes()
 		
-		self.assign3000BCGold()	
+#		self.assign3000BCGold()	
 		self.invalidateUHVs()
 		
 		gc.getGame().setVoteSourceReligion(1, iCatholicism, False)
@@ -538,23 +538,23 @@ class RiseAndFall:
 				if plot.getOwner() != -1:
 					utils.convertPlotCulture(plot, plot.getOwner(), 100, True)
 					
-		for x, y in [(48, 45), (50, 44), (50, 43), (50, 42), (49, 40)]:
-			utils.convertPlotCulture(gc.getMap().plot(x, y), iPortugal, 100, True)
+#		for x, y in [(48, 45), (50, 44), (50, 43), (50, 42), (49, 40)]:
+#			utils.convertPlotCulture(gc.getMap().plot(x, y), iPortugal, 100, True)
 			
-		for x, y in [(58, 49), (59, 49), (60, 49)]:
-			utils.convertPlotCulture(gc.getMap().plot(x, y), iGermany, 100, True)
+#		for x, y in [(58, 49), (59, 49), (60, 49)]:
+#			utils.convertPlotCulture(gc.getMap().plot(x, y), iGermany, 100, True)
 			
-		for x, y in [(62, 51)]:
-			utils.convertPlotCulture(gc.getMap().plot(x, y), iHolyRome, 100, True)
+#		for x, y in [(62, 51)]:
+#			utils.convertPlotCulture(gc.getMap().plot(x, y), iHolyRome, 100, True)
 			
-		for x, y in [(58, 52), (58, 53)]:
-			utils.convertPlotCulture(gc.getMap().plot(x, y), iNetherlands, 100, True)
+#		for x, y in [(58, 52), (58, 53)]:
+#			utils.convertPlotCulture(gc.getMap().plot(x, y), iNetherlands, 100, True)
 			
-		for x, y in [(64, 53), (66, 55)]:
-			utils.convertPlotCulture(gc.getMap().plot(x, y), iPoland, 100, True)
+#		for x, y in [(64, 53), (66, 55)]:
+#			utils.convertPlotCulture(gc.getMap().plot(x, y), iPoland, 100, True)
 			
-		for x, y in [(67, 58), (68, 59), (69, 56), (69, 54)]:
-			utils.convertPlotCulture(gc.getMap().plot(x, y), iRussia, 100, True)
+#		for x, y in [(67, 58), (68, 59), (69, 56), (69, 54)]:
+#			utils.convertPlotCulture(gc.getMap().plot(x, y), iRussia, 100, True)
 			
 	def prepareColonists(self):
 		for iPlayer in [iSpain, iFrance, iEngland, iPortugal, iNetherlands, iGermany, iVikings]:
@@ -580,23 +580,23 @@ class RiseAndFall:
 			gc.getPlayer(iPlayer).changeGold(utils.getTurns(dExtraGold1700AD[iPlayer]))
 		
 	def init1700ADDiplomacy(self):	
-		self.changeAttitudeExtra(iIndia, iMughals, -2)
-		self.changeAttitudeExtra(iPersia, iTurkey, -4)
-		self.changeAttitudeExtra(iPersia, iMughals, -2)
-		self.changeAttitudeExtra(iChina, iKorea, 2)
-		self.changeAttitudeExtra(iVikings, iRussia, -2)
-		self.changeAttitudeExtra(iVikings, iTurkey, -2)
-		self.changeAttitudeExtra(iSpain, iPortugal, 2)
-		self.changeAttitudeExtra(iFrance, iEngland, -4)
-		self.changeAttitudeExtra(iFrance, iNetherlands, 2)
-		self.changeAttitudeExtra(iFrance, iTurkey, -2)
-		self.changeAttitudeExtra(iEngland, iPortugal, 2)
-		self.changeAttitudeExtra(iEngland, iMughals, -2)
-		self.changeAttitudeExtra(iEngland, iTurkey, -2)
-		self.changeAttitudeExtra(iHolyRome, iTurkey, -4)
-		self.changeAttitudeExtra(iRussia, iTurkey, -4)
-		self.changeAttitudeExtra(iPortugal, iNetherlands, -2)
-		self.changeAttitudeExtra(iNetherlands, iTurkey, -2)
+#		self.changeAttitudeExtra(iIndia, iMughals, -2)
+#		self.changeAttitudeExtra(iPersia, iTurkey, -4)
+#		self.changeAttitudeExtra(iPersia, iMughals, -2)
+#		self.changeAttitudeExtra(iChina, iKorea, 2)
+#		self.changeAttitudeExtra(iVikings, iRussia, -2)
+#		self.changeAttitudeExtra(iVikings, iTurkey, -2)
+#		self.changeAttitudeExtra(iSpain, iPortugal, 2)
+#		self.changeAttitudeExtra(iFrance, iEngland, -4)
+#		self.changeAttitudeExtra(iFrance, iNetherlands, 2)
+#		self.changeAttitudeExtra(iFrance, iTurkey, -2)
+#		self.changeAttitudeExtra(iEngland, iPortugal, 2)
+#		self.changeAttitudeExtra(iEngland, iMughals, -2)
+#		self.changeAttitudeExtra(iEngland, iTurkey, -2)
+#		self.changeAttitudeExtra(iHolyRome, iTurkey, -4)
+#		self.changeAttitudeExtra(iRussia, iTurkey, -4)
+#		self.changeAttitudeExtra(iPortugal, iNetherlands, -2)
+#		self.changeAttitudeExtra(iNetherlands, iTurkey, -2)
 		
 		teamEngland.declareWar(iMughals, False, WarPlanTypes.WARPLAN_LIMITED)
 		teamIndia.declareWar(iMughals, False, WarPlanTypes.WARPLAN_TOTAL)
@@ -624,10 +624,10 @@ class RiseAndFall:
 		if utils.getScenario() == i600AD:
 		
 			# Byzantium
-			tCapital = Areas.getCapital(iByzantium)
-			lBuildings = [iWalls, iCastle, iBarracks, iStable, iGranary, iLibrary, iMarket, \
-				      iOrthodoxTemple, iByzantineHippodrome, iHagiaSophia, iTheodosianWalls]
-			city = utils.foundCapital(iByzantium, tCapital, 'Konstantinoupolis', 4, 250, lBuildings, [iJudaism, iCatholicism, iOrthodoxy])
+#			tCapital = Areas.getCapital(iByzantium)
+#			lBuildings = [iWalls, iCastle, iBarracks, iStable, iGranary, iLibrary, iMarket, \
+#				      iOrthodoxTemple, iByzantineHippodrome, iHagiaSophia, iTheodosianWalls]
+#			city = utils.foundCapital(iByzantium, tCapital, 'Konstantinoupolis', 4, 250, lBuildings, [iJudaism, iCatholicism, iOrthodoxy])
 			
 			# China
 			self.prepareChina()
@@ -638,73 +638,73 @@ class RiseAndFall:
 		if utils.getScenario() == i1700AD:
 			
 			# London
-			x, y = Areas.getCapital(iEngland)
-			pLondon = gc.getMap().plot(x, y).getPlotCity()
-			pLondon.setFreeSpecialistCount(iSpecialistGreatMerchant, 1)
+#			x, y = Areas.getCapital(iEngland)
+#			pLondon = gc.getMap().plot(x, y).getPlotCity()
+#			pLondon.setFreeSpecialistCount(iSpecialistGreatMerchant, 1)
 			
 			# Paris
-			x, y = Areas.getCapital(iFrance)
-			pParis = gc.getMap().plot(x, y).getPlotCity()
-			pParis.setFreeSpecialistCount(iSpecialistGreatScientist, 1)
+#			x, y = Areas.getCapital(iFrance)
+#			pParis = gc.getMap().plot(x, y).getPlotCity()
+#			pParis.setFreeSpecialistCount(iSpecialistGreatScientist, 1)
 			
 			# Netherlands
-			x, y = Areas.getCapital(iNetherlands)
-			pAmsterdam = gc.getMap().plot(x, y).getPlotCity()
-			pAmsterdam.setFreeSpecialistCount(iSpecialistGreatMerchant, 2)
+#			x, y = Areas.getCapital(iNetherlands)
+#			pAmsterdam = gc.getMap().plot(x, y).getPlotCity()
+#			pAmsterdam.setFreeSpecialistCount(iSpecialistGreatMerchant, 2)
 			
 			# Hamburg
-			x, y = tHamburg
-			pHamburg = gc.getMap().plot(x, y).getPlotCity()
-			pHamburg.setFreeSpecialistCount(iSpecialistGreatMerchant, 1)
-			pHamburg.setCulture(iNetherlands, 0, True)
-			gc.getMap().plot(x, y).setCulture(iNetherlands, 0, True)
+#			x, y = tHamburg
+#			pHamburg = gc.getMap().plot(x, y).getPlotCity()
+#			pHamburg.setFreeSpecialistCount(iSpecialistGreatMerchant, 1)
+#			pHamburg.setCulture(iNetherlands, 0, True)
+#			gc.getMap().plot(x, y).setCulture(iNetherlands, 0, True)
 			
 			# Milan
-			x, y = tMilan
-			pMilan = gc.getMap().plot(x, y).getPlotCity()
-			pMilan.setFreeSpecialistCount(iSpecialistGreatMerchant, 2)
-			pMilan.setFreeSpecialistCount(iSpecialistGreatEngineer, 1)
+#			x, y = tMilan
+#			pMilan = gc.getMap().plot(x, y).getPlotCity()
+#			pMilan.setFreeSpecialistCount(iSpecialistGreatMerchant, 2)
+#			pMilan.setFreeSpecialistCount(iSpecialistGreatEngineer, 1)
 			
 			# Kyoto
-			x, y = Areas.getCapital(iJapan)
-			pKyoto = gc.getMap().plot(x, y).getPlotCity()
-			pKyoto.setFreeSpecialistCount(iSpecialistGreatMerchant, 1)
+#			x, y = Areas.getCapital(iJapan)
+#			pKyoto = gc.getMap().plot(x, y).getPlotCity()
+#			pKyoto.setFreeSpecialistCount(iSpecialistGreatMerchant, 1)
 			
 			# Mecca
-			pMecca = gc.getGame().getHolyCity(iIslam)
-			pMecca.setFreeSpecialistCount(iSpecialistGreatProphet, 2)
+#			pMecca = gc.getGame().getHolyCity(iIslam)
+#			pMecca.setFreeSpecialistCount(iSpecialistGreatProphet, 2)
 			
 			# Rome
-			x, y = Areas.getCapital(iRome)
-			pRome = gc.getMap().plot(x, y).getPlotCity()
-			pRome.setFreeSpecialistCount(iSpecialistGreatProphet, 1)
+#			x, y = Areas.getCapital(iRome)
+#			pRome = gc.getMap().plot(x, y).getPlotCity()
+#			pRome.setFreeSpecialistCount(iSpecialistGreatProphet, 1)
 			
 			# Baghdad
-			x, y = tBaghdad
-			pBaghdad = gc.getMap().plot(x, y).getPlotCity()
-			pBaghdad.setFreeSpecialistCount(iSpecialistGreatProphet, 1)
+#			x, y = tBaghdad
+#			pBaghdad = gc.getMap().plot(x, y).getPlotCity()
+#			pBaghdad.setFreeSpecialistCount(iSpecialistGreatProphet, 1)
 			
 			# Pataliputra
-			pPataliputra = gc.getGame().getHolyCity(iHinduism)
-			pPataliputra.setFreeSpecialistCount(iSpecialistGreatProphet, 2)
+#			pPataliputra = gc.getGame().getHolyCity(iHinduism)
+#			pPataliputra.setFreeSpecialistCount(iSpecialistGreatProphet, 2)
 			
 			# Lhasa
-			x, y = Areas.getCapital(iTibet)
-			pLhasa = gc.getMap().plot(x, y).getPlotCity()
-			pLhasa.setFreeSpecialistCount(iSpecialistGreatProphet, 2)
+#			x, y = Areas.getCapital(iTibet)
+#			pLhasa = gc.getMap().plot(x, y).getPlotCity()
+#			pLhasa.setFreeSpecialistCount(iSpecialistGreatProphet, 2)
 			
 			# Ayutthaya
-			x, y = Areas.getCapital(iThailand)
-			pAyutthaya = gc.getMap().plot(x, y).getPlotCity()
-			pAyutthaya.setFreeSpecialistCount(iSpecialistGreatProphet, 1)
+#			x, y = Areas.getCapital(iThailand)
+#			pAyutthaya = gc.getMap().plot(x, y).getPlotCity()
+#			pAyutthaya.setFreeSpecialistCount(iSpecialistGreatProphet, 1)
 			
 			# Chengdu
 			pChengdu = gc.getMap().plot(99, 41).getPlotCity()
 			pChengdu.setCulture(iChina, 100, True)
 			
 			# Mumbai
-			pMumbai = gc.getMap().plot(88, 34).getPlotCity()
-			pMumbai.setFreeSpecialistCount(iSpecialistGreatGeneral, 1)
+#			pMumbai = gc.getMap().plot(88, 34).getPlotCity()
+#			pMumbai.setFreeSpecialistCount(iSpecialistGreatGeneral, 1)
 			
 	def flipStartingTerritory(self):
 	
@@ -715,7 +715,7 @@ class RiseAndFall:
 			tBR1 = (76, 45)
 			tTL2 = (66, 34)
 			tBR2 = (70, 37)
-			self.startingFlip(iByzantium, [(tTL1, tBR1), (tTL2, tBR2)])
+#			self.startingFlip(iByzantium, [(tTL1, tBR1), (tTL2, tBR2)])
 			
 			# China
 			tTL, tBR = Areas.tBirthArea[iChina]
@@ -732,8 +732,8 @@ class RiseAndFall:
 			self.startingFlip(iChina, [(tTibetTL, tTibetBR), (tManchuriaTL, tManchuriaBR)])
 			
 			# Russia (Sankt Peterburg)
-			utils.convertPlotCulture(gc.getMap().plot(68, 58), iRussia, 100, True)
-			utils.convertPlotCulture(gc.getMap().plot(67, 57), iRussia, 100, True)
+#			utils.convertPlotCulture(gc.getMap().plot(68, 58), iRussia, 100, True)
+#			utils.convertPlotCulture(gc.getMap().plot(67, 57), iRussia, 100, True)
 			
 			
 	def startingFlip(self, iPlayer, lRegionList):
@@ -3542,119 +3542,120 @@ class RiseAndFall:
 	
 		# China
 		tCapital = tBeijing
-		utils.makeUnit(iMusketman, iChina, tCapital, 12)
-		utils.makeUnit(iBombard, iChina, tCapital, 5)
+#		utils.makeUnit(iMusketman, iChina, tCapital, 12)
+#		utils.makeUnit(iBombard, iChina, tCapital, 5)
 		
 		# India
 		tCapital = tMumbai
-		utils.makeUnit(iMusketman, iIndia, tCapital, 8)
-		utils.makeUnit(iBombard, iIndia, tCapital, 5)
-		utils.makeUnit(iCuirassier, iIndia, tCapital, 3)
+#		utils.makeUnit(iMusketman, iIndia, tCapital, 8)
+#		utils.makeUnit(iBombard, iIndia, tCapital, 5)
+#		utils.makeUnit(iCuirassier, iIndia, tCapital, 3)
 		
 		# Tamils
 		tCapital = tMysore
-		utils.makeUnit(iMusketman, iTamils, tCapital, 6)
-		utils.makeUnit(iBombard, iTamils, tCapital, 4)
+#		utils.makeUnit(iMusketman, iTamils, tCapital, 6)
+#		utils.makeUnit(iBombard, iTamils, tCapital, 4)
 		
 		# Persia
 		tCapital = tEsfahan
-		utils.makeUnit(iIranianQizilbash, iPersia, tCapital, 10)
-		utils.makeUnit(iBombard, iPersia, tCapital, 4)
+#		utils.makeUnit(iIranianQizilbash, iPersia, tCapital, 10)
+#		utils.makeUnit(iBombard, iPersia, tCapital, 4)
 		
 		# Korea
 		tCapital = Areas.getCapital(iKorea)
-		utils.makeUnit(iMusketman, iKorea, tCapital, 6)
-		utils.makeUnit(iBombard, iKorea, tCapital, 4)
+#		utils.makeUnit(iMusketman, iKorea, tCapital, 6)
+#		utils.makeUnit(iBombard, iKorea, tCapital, 4)
 		
 		# Japan
 		tCapital = Areas.getCapital(iJapan)
-		utils.makeUnit(iMusketman, iJapan, tCapital, 10)
-		utils.makeUnit(iBombard, iJapan, tCapital, 4)
-		if utils.getHumanID() != iJapan: utils.makeUnit(iSettler, iJapan, tCapital, 1)
+#		utils.makeUnit(iMusketman, iJapan, tCapital, 10)
+#		utils.makeUnit(iBombard, iJapan, tCapital, 4)
+		if utils.getHumanID() != iJapan:
+			utils.makeUnit(iSettler, iJapan, tCapital, 1)
 		
 		# Vikings
 		tCapital = tStockholm
-		utils.makeUnit(iMusketman, iVikings, tCapital, 8)
-		utils.makeUnit(iBombard, iVikings, tCapital, 4)
+#		utils.makeUnit(iMusketman, iVikings, tCapital, 8)
+#		utils.makeUnit(iBombard, iVikings, tCapital, 4)
 		
 		# Spain
 		tCapital = Areas.getCapital(iSpain)
-		utils.makeUnit(iMusketman, iSpain, tCapital, 6)
-		utils.makeUnit(iSpanishConquistador, iSpain, tCapital, 4)
-		utils.makeUnit(iBombard, iSpain, tCapital, 2)
+#		utils.makeUnit(iMusketman, iSpain, tCapital, 6)
+#		utils.makeUnit(iSpanishConquistador, iSpain, tCapital, 4)
+3		utils.makeUnit(iBombard, iSpain, tCapital, 2)
 		
 		# France
 		tCapital = Areas.getCapital(iFrance)
-		utils.makeUnit(iRifleman, iFrance, tCapital, 12)
-		utils.makeUnit(iCuirassier, iFrance, tCapital, 4)
-		utils.makeUnit(iFrenchHeavyCannon, iFrance, tCapital, 5)
+#		utils.makeUnit(iRifleman, iFrance, tCapital, 12)
+#		utils.makeUnit(iCuirassier, iFrance, tCapital, 4)
+#		utils.makeUnit(iFrenchHeavyCannon, iFrance, tCapital, 5)
 		
 		# England
 		tCapital = Areas.getCapital(iEngland)
-		utils.makeUnit(iEnglishRedcoat, iEngland, tCapital, 8)
-		utils.makeUnit(iCannon, iEngland, tCapital, 4)
-		utils.makeUnit(iGalleon, iEngland, tCapital, 4)
+#		utils.makeUnit(iEnglishRedcoat, iEngland, tCapital, 8)
+#		utils.makeUnit(iCannon, iEngland, tCapital, 4)
+#		utils.makeUnit(iGalleon, iEngland, tCapital, 4)
 		
 		# Austria
 		tCapital = tVienna
-		utils.makeUnit(iRifleman, iHolyRome, tCapital, 6)
-		utils.makeUnit(iCannon, iHolyRome, tCapital, 2)
+#		utils.makeUnit(iRifleman, iHolyRome, tCapital, 6)
+#		utils.makeUnit(iCannon, iHolyRome, tCapital, 2)
 		
 		# Russia
 		tCapital = Areas.getCapital(iRussia)
-		utils.makeUnit(iMusketman, iRussia, tCapital, 8)
-		utils.makeUnit(iCuirassier, iRussia, tCapital, 4)
-		utils.makeUnit(iBombard, iRussia, tCapital, 4)
+#		utils.makeUnit(iMusketman, iRussia, tCapital, 8)
+#		utils.makeUnit(iCuirassier, iRussia, tCapital, 4)
+#		utils.makeUnit(iBombard, iRussia, tCapital, 4)
 		
 		# Poland
 		tCapital = tWarsaw
-		utils.makeUnit(iMusketman, iPoland, tCapital, 4)
-		utils.makeUnit(iPolishWingedHussar, iPoland, tCapital, 6)
-		utils.makeUnit(iBombard, iPoland, tCapital, 2)
+#		utils.makeUnit(iMusketman, iPoland, tCapital, 4)
+#		utils.makeUnit(iPolishWingedHussar, iPoland, tCapital, 6)
+#		utils.makeUnit(iBombard, iPoland, tCapital, 2)
 		
 		# Portugal
 		tCapital = Areas.getCapital(iPortugal)
-		utils.makeUnit(iMusketman, iPortugal, tCapital, 6)
-		utils.makeUnit(iBombard, iPortugal, tCapital, 2)
-		utils.makeUnit(iGalleon, iPortugal, tCapital, 3)
+#		utils.makeUnit(iMusketman, iPortugal, tCapital, 6)
+#		utils.makeUnit(iBombard, iPortugal, tCapital, 2)
+#		utils.makeUnit(iGalleon, iPortugal, tCapital, 3)
 		
 		# Mughals
 		tCapital = Areas.getCapital(iMughals)
-		utils.makeUnit(iMusketman, iMughals, tCapital, 5)
-		utils.makeUnit(iPikeman, iMughals, tCapital, 2)
-		utils.makeUnit(iMughalSiegeElephant, iMughals, tCapital, 2)
+#		utils.makeUnit(iMusketman, iMughals, tCapital, 5)
+#		utils.makeUnit(iPikeman, iMughals, tCapital, 2)
+#		utils.makeUnit(iMughalSiegeElephant, iMughals, tCapital, 2)
 		
 		# Turkey
 		tCapital = tIstanbul
-		utils.makeUnit(iOttomanJanissary, iTurkey, tCapital, 10)
-		utils.makeUnit(iCuirassier, iTurkey, tCapital, 4)
-		utils.makeUnit(iBombard, iTurkey, tCapital, 5)
+#		utils.makeUnit(iOttomanJanissary, iTurkey, tCapital, 10)
+#		utils.makeUnit(iCuirassier, iTurkey, tCapital, 4)
+#		utils.makeUnit(iBombard, iTurkey, tCapital, 5)
 		
 		# Thailand
 		tCapital = Areas.getCapital(iThailand)
-		utils.makeUnit(iMusketman, iThailand, tCapital, 4)
-		utils.makeUnit(iPikeman, iThailand, tCapital, 2)
-		utils.makeUnit(iThaiChangSuek, iThailand, tCapital, 4)
-		utils.makeUnit(iBombard, iThailand, tCapital, 2)
+#		utils.makeUnit(iMusketman, iThailand, tCapital, 4)
+#		utils.makeUnit(iPikeman, iThailand, tCapital, 2)
+#		utils.makeUnit(iThaiChangSuek, iThailand, tCapital, 4)
+#		utils.makeUnit(iBombard, iThailand, tCapital, 2)
 		
 		# Congo
 		tCapital = Areas.getCapital(iCongo)
-		utils.makeUnit(iSettler, iCongo, tCapital, 1)
-		utils.makeUnit(iCongolesePombos, iCongo, tCapital, 6)
-		utils.makeUnit(iCatapult, iCongo, tCapital, 2)
-		utils.makeUnit(iLongbowman, iCongo, tCapital, 2)
-		utils.makeUnit(iNativeSlave, iCongo, tCapital, 5)
+#		utils.makeUnit(iSettler, iCongo, tCapital, 1)
+#		utils.makeUnit(iCongolesePombos, iCongo, tCapital, 6)
+#		utils.makeUnit(iCatapult, iCongo, tCapital, 2)
+#		utils.makeUnit(iLongbowman, iCongo, tCapital, 2)
+#		utils.makeUnit(iNativeSlave, iCongo, tCapital, 5)
 		
 		# Netherlands
 		tCapital = Areas.getCapital(iNetherlands)
-		utils.makeUnit(iRifleman, iNetherlands, tCapital, 5)
-		utils.makeUnit(iBombard, iNetherlands, tCapital, 2)
-		utils.makeUnit(iDutchEastIndiaman, iNetherlands, tCapital, 3)
+#		utils.makeUnit(iRifleman, iNetherlands, tCapital, 5)
+#		utils.makeUnit(iBombard, iNetherlands, tCapital, 2)
+#		utils.makeUnit(iDutchEastIndiaman, iNetherlands, tCapital, 3)
 		
 		# Prussia
 		tCapital = Areas.getCapital(iGermany)
-		utils.makeUnit(iRifleman, iGermany, tCapital, 8)
-		utils.makeUnit(iCannon, iGermany, tCapital, 3)
+#		utils.makeUnit(iRifleman, iGermany, tCapital, 8)
+#		utils.makeUnit(iCannon, iGermany, tCapital, 3)
 		
 		for iPlayer in range(iNumPlayers):
 			if tBirth[iPlayer] > utils.getScenarioStartYear() and utils.getHumanID() == iPlayer:
@@ -3672,36 +3673,36 @@ class RiseAndFall:
 		utils.makeUnit(iWorker, iChina, tCapital, 2)
 		
 		tCapital = Areas.getCapital(iJapan)
-		utils.makeUnit(iSettler, iJapan, tCapital, 3)
-		utils.makeUnit(iBuddhistMissionary, iJapan, tCapital, 3)
-		utils.makeUnit(iSwordsman, iJapan, tCapital, 2)
-		utils.makeUnit(iArcher, iJapan, tCapital, 2)
+#		utils.makeUnit(iSettler, iJapan, tCapital, 3)
+#		utils.makeUnit(iBuddhistMissionary, iJapan, tCapital, 3)
+#		utils.makeUnit(iSwordsman, iJapan, tCapital, 2)
+#		utils.makeUnit(iArcher, iJapan, tCapital, 2)
 		tSeaPlot = self.findSeaPlots(tCapital, 1, iJapan)
-		if (tSeaPlot):				
-			utils.makeUnit(iWorkboat, iJapan, tSeaPlot, 2)
+#		if (tSeaPlot):
+#			utils.makeUnit(iWorkboat, iJapan, tSeaPlot, 2)
 
 		if utils.getHumanID() != iJapan:
 			utils.makeUnit(iCrossbowman, iJapan, tCapital, 2)
 			utils.makeUnit(iJapaneseSamurai, iJapan, tCapital, 3)
 
 		tCapital = Areas.getCapital(iVikings)
-		utils.makeUnit(iSettler, iVikings, tCapital, 1)
-		utils.makeUnit(iLongbowman, iVikings, tCapital, 2)
-		utils.makeUnit(iAxeman, iVikings, tCapital, 2)
-		utils.makeUnit(iScout, iVikings, tCapital, 1)
-		pVikings.initUnit(iSwordsman, tCapital[0], tCapital[1], UnitAITypes.UNITAI_ATTACK_CITY, DirectionTypes.DIRECTION_SOUTH)
-		utils.makeUnit(iSwordsman, iVikings, tCapital, 1)				
+#		utils.makeUnit(iSettler, iVikings, tCapital, 1)
+#		utils.makeUnit(iLongbowman, iVikings, tCapital, 2)
+#		utils.makeUnit(iAxeman, iVikings, tCapital, 2)
+#		utils.makeUnit(iScout, iVikings, tCapital, 1)
+#		pVikings.initUnit(iSwordsman, tCapital[0], tCapital[1], UnitAITypes.UNITAI_ATTACK_CITY, DirectionTypes.DIRECTION_SOUTH)
+#		utils.makeUnit(iSwordsman, iVikings, tCapital, 1)
 		tSeaPlot = self.findSeaPlots(tCapital, 1, iVikings)
-		if (tSeaPlot):				
-			utils.makeUnit(iWorkboat, iVikings, tSeaPlot, 1)
-			pVikings.initUnit(iGalley, tSeaPlot[0], tSeaPlot[1], UnitAITypes.UNITAI_SETTLER_SEA, DirectionTypes.DIRECTION_SOUTH)
+		if (tSeaPlot):
+#			utils.makeUnit(iWorkboat, iVikings, tSeaPlot, 1)
+#			pVikings.initUnit(iGalley, tSeaPlot[0], tSeaPlot[1], UnitAITypes.UNITAI_SETTLER_SEA, DirectionTypes.DIRECTION_SOUTH)
 			if utils.getHumanID() == iVikings:
 				utils.makeUnit(iSettler, iVikings, tSeaPlot, 1)
 				utils.makeUnit(iLongbowman, iVikings, tSeaPlot, 1)
-			pVikings.initUnit(iGalley, tSeaPlot[0], tSeaPlot[1], UnitAITypes.UNITAI_EXPLORE_SEA, DirectionTypes.DIRECTION_SOUTH)				  #utils.makeUnit(iSettler, iCiv, tSeaPlot, 1)
-			pVikings.initUnit(iGalley, tSeaPlot[0], tSeaPlot[1], UnitAITypes.UNITAI_EXPLORE_SEA, DirectionTypes.DIRECTION_SOUTH)
+#			pVikings.initUnit(iGalley, tSeaPlot[0], tSeaPlot[1], UnitAITypes.UNITAI_EXPLORE_SEA, DirectionTypes.DIRECTION_SOUTH)
 			#utils.makeUnit(iSettler, iCiv, tSeaPlot, 1)
-			
+#			pVikings.initUnit(iGalley, tSeaPlot[0], tSeaPlot[1], UnitAITypes.UNITAI_EXPLORE_SEA, DirectionTypes.DIRECTION_SOUTH)
+			#utils.makeUnit(iSettler, iCiv, tSeaPlot, 1)
 		# start AI settler and garrison in Denmark and Sweden
 		if utils.getHumanID() != iVikings:
 			utils.makeUnit(iSettler, iVikings, (60, 56), 1)
@@ -3713,21 +3714,21 @@ class RiseAndFall:
 			utils.makeUnit(iLongbowman, iVikings, tCapital, 2)
 
 		tCapital = Areas.getCapital(iByzantium)
-		utils.makeUnit(iSpearman, iByzantium, tCapital, 2)
-		utils.makeUnit(iArcher, iByzantium, tCapital, 3)
-		utils.makeUnit(iByzantineCataphract, iByzantium, tCapital, 1)
+#		utils.makeUnit(iSpearman, iByzantium, tCapital, 2)
+#		utils.makeUnit(iArcher, iByzantium, tCapital, 3)
+#		utils.makeUnit(iByzantineCataphract, iByzantium, tCapital, 1)
 		tSeaPlot = self.findSeaPlots(tCapital, 1, iByzantium)
-		if tSeaPlot:
-			utils.makeUnit(iGalley, iByzantium, tSeaPlot, 2)
-			utils.makeUnit(iTrireme, iByzantium, tSeaPlot, 2)
+#		if tSeaPlot:
+#			utils.makeUnit(iGalley, iByzantium, tSeaPlot, 2)
+#			utils.makeUnit(iTrireme, iByzantium, tSeaPlot, 2)
 
 		tCapital = Areas.getCapital(iKorea)
-		utils.makeUnit(iSettler, iKorea, tCapital, 2)
-		utils.makeUnit(iBuddhistMissionary, iKorea, tCapital, 1)
-		utils.makeUnit(iConfucianMissionary, iKorea, tCapital, 1)
-		utils.makeUnit(iArcher, iKorea, tCapital, 2)
-		utils.makeUnit(iAxeman, iKorea, tCapital, 3)
-		utils.makeUnit(iHorseArcher, iKorea, tCapital, 1)
+#		utils.makeUnit(iSettler, iKorea, tCapital, 2)
+#		utils.makeUnit(iBuddhistMissionary, iKorea, tCapital, 1)
+#		utils.makeUnit(iConfucianMissionary, iKorea, tCapital, 1)
+#		utils.makeUnit(iArcher, iKorea, tCapital, 2)
+#		utils.makeUnit(iAxeman, iKorea, tCapital, 3)
+#		utils.makeUnit(iHorseArcher, iKorea, tCapital, 1)
 
 		if utils.getHumanID() != iKorea:
 			utils.makeUnit(iHeavySwordsman, iKorea, tCapital, 2)
@@ -3743,15 +3744,15 @@ class RiseAndFall:
 	
 		for iPlayer in range(iNumPlayers):
 			tCapital = Areas.getCapital(iPlayer)
-			if tBirth[iPlayer] == utils.getScenarioStartYear() and iPlayer != iHarappa:
-				utils.makeUnit(iSettler, iPlayer, tCapital, 1)
-				utils.makeUnit(iWarrior, iPlayer, tCapital, 1)
-			elif iPlayer == iHarappa and (self.getPlayerEnabled(iPlayer) or gc.getPlayer(iPlayer).isHuman()):
+#			if tBirth[iPlayer] == utils.getScenarioStartYear() and iPlayer != iHarappa:
+#				utils.makeUnit(iSettler, iPlayer, tCapital, 1)
+#				utils.makeUnit(iWarrior, iPlayer, tCapital, 1)
+			if iPlayer == iHarappa and (self.getPlayerEnabled(iPlayer) or gc.getPlayer(iPlayer).isHuman()):
 				utils.makeUnit(iHarappanCityBuilder, iPlayer, tCapital, 1)
 				utils.makeUnit(iWarrior, iPlayer, tCapital, 1)
-			elif gc.getPlayer(iPlayer).isHuman():
-				utils.makeUnit(iSettler, iPlayer, tCapital, 1)
-				utils.makeUnit(iWarrior, iPlayer, tCapital, 1)
+#			elif gc.getPlayer(iPlayer).isHuman():
+#				utils.makeUnit(iSettler, iPlayer, tCapital, 1)
+#				utils.makeUnit(iWarrior, iPlayer, tCapital, 1)
 			
 		
 		

--- a/Assets/Python/RiseAndFall.py
+++ b/Assets/Python/RiseAndFall.py
@@ -535,6 +535,24 @@ class RiseAndFall:
 				if plot.getOwner() != -1:
 					utils.convertPlotCulture(plot, plot.getOwner(), 100, True)
 					
+		for x, y in [(48, 45), (50, 44), (50, 43), (50, 42), (49, 40)]:
+			utils.convertPlotCulture(gc.getMap().plot(x, y), iPortugal, 100, True)
+			
+		for x, y in [(58, 49), (59, 49), (60, 49)]:
+			utils.convertPlotCulture(gc.getMap().plot(x, y), iGermany, 100, True)
+			
+		for x, y in [(62, 51)]:
+			utils.convertPlotCulture(gc.getMap().plot(x, y), iHolyRome, 100, True)
+			
+		for x, y in [(58, 52), (58, 53)]:
+			utils.convertPlotCulture(gc.getMap().plot(x, y), iNetherlands, 100, True)
+			
+		for x, y in [(64, 53), (66, 55)]:
+			utils.convertPlotCulture(gc.getMap().plot(x, y), iPoland, 100, True)
+			
+		for x, y in [(67, 58), (68, 59), (69, 56), (69, 54)]:
+			utils.convertPlotCulture(gc.getMap().plot(x, y), iRussia, 100, True)
+			
 	def prepareColonists(self):
 		for iPlayer in [iSpain, iFrance, iEngland, iPortugal, iNetherlands, iGermany, iVikings]:
 			self.setAstronomyTurn(iPlayer, getTurnForYear(1700))
@@ -614,6 +632,11 @@ class RiseAndFall:
 			tManchuriaTL = (105, 51)
 			tManchuriaBR = (109, 55)
 			self.startingFlip(iChina, [(tTibetTL, tTibetBR), (tManchuriaTL, tManchuriaBR)])
+			
+			# Russia (Sankt Peterburg)
+			utils.convertPlotCulture(gc.getMap().plot(68, 58), iRussia, 100, True)
+			utils.convertPlotCulture(gc.getMap().plot(67, 57), iRussia, 100, True)
+			
 			
 	def startingFlip(self, iPlayer, lRegionList):
 	

--- a/Assets/Python/RiseAndFall.py
+++ b/Assets/Python/RiseAndFall.py
@@ -3582,7 +3582,7 @@ class RiseAndFall:
 		tCapital = Areas.getCapital(iSpain)
 #		utils.makeUnit(iMusketman, iSpain, tCapital, 6)
 #		utils.makeUnit(iSpanishConquistador, iSpain, tCapital, 4)
-3		utils.makeUnit(iBombard, iSpain, tCapital, 2)
+#		utils.makeUnit(iBombard, iSpain, tCapital, 2)
 		
 		# France
 		tCapital = Areas.getCapital(iFrance)

--- a/Assets/Python/RiseAndFall.py
+++ b/Assets/Python/RiseAndFall.py
@@ -457,12 +457,10 @@ class RiseAndFall:
 		if utils.getScenario() == i600AD:
 			Civilizations.initScenarioTechs(i600AD)
 			self.create600ADstartingUnits()
-#			self.assign600ADGold()
 			
 		if utils.getScenario() == i1700AD:
 			Civilizations.initScenarioTechs(i1700AD)
 			self.create1700ADstartingUnits()
-#			self.assign1700ADGold()
 			self.init1700ADDiplomacy()
 			self.prepareColonists()
 			self.adjust1700ADCulture()
@@ -472,7 +470,6 @@ class RiseAndFall:
 			
 			pChina.updateTradeRoutes()
 		
-#		self.assign3000BCGold()	
 		self.invalidateUHVs()
 		
 		gc.getGame().setVoteSourceReligion(1, iCatholicism, False)
@@ -538,24 +535,6 @@ class RiseAndFall:
 				if plot.getOwner() != -1:
 					utils.convertPlotCulture(plot, plot.getOwner(), 100, True)
 					
-#		for x, y in [(48, 45), (50, 44), (50, 43), (50, 42), (49, 40)]:
-#			utils.convertPlotCulture(gc.getMap().plot(x, y), iPortugal, 100, True)
-			
-#		for x, y in [(58, 49), (59, 49), (60, 49)]:
-#			utils.convertPlotCulture(gc.getMap().plot(x, y), iGermany, 100, True)
-			
-#		for x, y in [(62, 51)]:
-#			utils.convertPlotCulture(gc.getMap().plot(x, y), iHolyRome, 100, True)
-			
-#		for x, y in [(58, 52), (58, 53)]:
-#			utils.convertPlotCulture(gc.getMap().plot(x, y), iNetherlands, 100, True)
-			
-#		for x, y in [(64, 53), (66, 55)]:
-#			utils.convertPlotCulture(gc.getMap().plot(x, y), iPoland, 100, True)
-			
-#		for x, y in [(67, 58), (68, 59), (69, 56), (69, 54)]:
-#			utils.convertPlotCulture(gc.getMap().plot(x, y), iRussia, 100, True)
-			
 	def prepareColonists(self):
 		for iPlayer in [iSpain, iFrance, iEngland, iPortugal, iNetherlands, iGermany, iVikings]:
 			self.setAstronomyTurn(iPlayer, getTurnForYear(1700))
@@ -579,24 +558,7 @@ class RiseAndFall:
 		for iPlayer in dExtraGold1700AD:
 			gc.getPlayer(iPlayer).changeGold(utils.getTurns(dExtraGold1700AD[iPlayer]))
 		
-	def init1700ADDiplomacy(self):	
-#		self.changeAttitudeExtra(iIndia, iMughals, -2)
-#		self.changeAttitudeExtra(iPersia, iTurkey, -4)
-#		self.changeAttitudeExtra(iPersia, iMughals, -2)
-#		self.changeAttitudeExtra(iChina, iKorea, 2)
-#		self.changeAttitudeExtra(iVikings, iRussia, -2)
-#		self.changeAttitudeExtra(iVikings, iTurkey, -2)
-#		self.changeAttitudeExtra(iSpain, iPortugal, 2)
-#		self.changeAttitudeExtra(iFrance, iEngland, -4)
-#		self.changeAttitudeExtra(iFrance, iNetherlands, 2)
-#		self.changeAttitudeExtra(iFrance, iTurkey, -2)
-#		self.changeAttitudeExtra(iEngland, iPortugal, 2)
-#		self.changeAttitudeExtra(iEngland, iMughals, -2)
-#		self.changeAttitudeExtra(iEngland, iTurkey, -2)
-#		self.changeAttitudeExtra(iHolyRome, iTurkey, -4)
-#		self.changeAttitudeExtra(iRussia, iTurkey, -4)
-#		self.changeAttitudeExtra(iPortugal, iNetherlands, -2)
-#		self.changeAttitudeExtra(iNetherlands, iTurkey, -2)
+	def init1700ADDiplomacy(self):
 		
 		teamEngland.declareWar(iMughals, False, WarPlanTypes.WARPLAN_LIMITED)
 		teamIndia.declareWar(iMughals, False, WarPlanTypes.WARPLAN_TOTAL)
@@ -623,12 +585,6 @@ class RiseAndFall:
 	def foundCapitals(self):	
 		if utils.getScenario() == i600AD:
 		
-			# Byzantium
-#			tCapital = Areas.getCapital(iByzantium)
-#			lBuildings = [iWalls, iCastle, iBarracks, iStable, iGranary, iLibrary, iMarket, \
-#				      iOrthodoxTemple, iByzantineHippodrome, iHagiaSophia, iTheodosianWalls]
-#			city = utils.foundCapital(iByzantium, tCapital, 'Konstantinoupolis', 4, 250, lBuildings, [iJudaism, iCatholicism, iOrthodoxy])
-			
 			# China
 			self.prepareChina()
 			tCapital = Areas.getCapital(iChina)
@@ -637,85 +593,13 @@ class RiseAndFall:
 			
 		if utils.getScenario() == i1700AD:
 			
-			# London
-#			x, y = Areas.getCapital(iEngland)
-#			pLondon = gc.getMap().plot(x, y).getPlotCity()
-#			pLondon.setFreeSpecialistCount(iSpecialistGreatMerchant, 1)
-			
-			# Paris
-#			x, y = Areas.getCapital(iFrance)
-#			pParis = gc.getMap().plot(x, y).getPlotCity()
-#			pParis.setFreeSpecialistCount(iSpecialistGreatScientist, 1)
-			
-			# Netherlands
-#			x, y = Areas.getCapital(iNetherlands)
-#			pAmsterdam = gc.getMap().plot(x, y).getPlotCity()
-#			pAmsterdam.setFreeSpecialistCount(iSpecialistGreatMerchant, 2)
-			
-			# Hamburg
-#			x, y = tHamburg
-#			pHamburg = gc.getMap().plot(x, y).getPlotCity()
-#			pHamburg.setFreeSpecialistCount(iSpecialistGreatMerchant, 1)
-#			pHamburg.setCulture(iNetherlands, 0, True)
-#			gc.getMap().plot(x, y).setCulture(iNetherlands, 0, True)
-			
-			# Milan
-#			x, y = tMilan
-#			pMilan = gc.getMap().plot(x, y).getPlotCity()
-#			pMilan.setFreeSpecialistCount(iSpecialistGreatMerchant, 2)
-#			pMilan.setFreeSpecialistCount(iSpecialistGreatEngineer, 1)
-			
-			# Kyoto
-#			x, y = Areas.getCapital(iJapan)
-#			pKyoto = gc.getMap().plot(x, y).getPlotCity()
-#			pKyoto.setFreeSpecialistCount(iSpecialistGreatMerchant, 1)
-			
-			# Mecca
-#			pMecca = gc.getGame().getHolyCity(iIslam)
-#			pMecca.setFreeSpecialistCount(iSpecialistGreatProphet, 2)
-			
-			# Rome
-#			x, y = Areas.getCapital(iRome)
-#			pRome = gc.getMap().plot(x, y).getPlotCity()
-#			pRome.setFreeSpecialistCount(iSpecialistGreatProphet, 1)
-			
-			# Baghdad
-#			x, y = tBaghdad
-#			pBaghdad = gc.getMap().plot(x, y).getPlotCity()
-#			pBaghdad.setFreeSpecialistCount(iSpecialistGreatProphet, 1)
-			
-			# Pataliputra
-#			pPataliputra = gc.getGame().getHolyCity(iHinduism)
-#			pPataliputra.setFreeSpecialistCount(iSpecialistGreatProphet, 2)
-			
-			# Lhasa
-#			x, y = Areas.getCapital(iTibet)
-#			pLhasa = gc.getMap().plot(x, y).getPlotCity()
-#			pLhasa.setFreeSpecialistCount(iSpecialistGreatProphet, 2)
-			
-			# Ayutthaya
-#			x, y = Areas.getCapital(iThailand)
-#			pAyutthaya = gc.getMap().plot(x, y).getPlotCity()
-#			pAyutthaya.setFreeSpecialistCount(iSpecialistGreatProphet, 1)
-			
 			# Chengdu
 			pChengdu = gc.getMap().plot(99, 41).getPlotCity()
 			pChengdu.setCulture(iChina, 100, True)
-			
-			# Mumbai
-#			pMumbai = gc.getMap().plot(88, 34).getPlotCity()
-#			pMumbai.setFreeSpecialistCount(iSpecialistGreatGeneral, 1)
-			
+
 	def flipStartingTerritory(self):
 	
 		if utils.getScenario() == i600AD:
-		
-			# Byzantium
-			tTL1 = (62, 37)
-			tBR1 = (76, 45)
-			tTL2 = (66, 34)
-			tBR2 = (70, 37)
-#			self.startingFlip(iByzantium, [(tTL1, tBR1), (tTL2, tBR2)])
 			
 			# China
 			tTL, tBR = Areas.tBirthArea[iChina]
@@ -730,11 +614,6 @@ class RiseAndFall:
 			tManchuriaTL = (105, 51)
 			tManchuriaBR = (109, 55)
 			self.startingFlip(iChina, [(tTibetTL, tTibetBR), (tManchuriaTL, tManchuriaBR)])
-			
-			# Russia (Sankt Peterburg)
-#			utils.convertPlotCulture(gc.getMap().plot(68, 58), iRussia, 100, True)
-#			utils.convertPlotCulture(gc.getMap().plot(67, 57), iRussia, 100, True)
-			
 			
 	def startingFlip(self, iPlayer, lRegionList):
 	
@@ -3539,123 +3418,11 @@ class RiseAndFall:
 			utils.makeUnit(iWorker, iCiv, tPlot, 3)
 			
 	def create1700ADstartingUnits(self):
-	
-		# China
-		tCapital = tBeijing
-#		utils.makeUnit(iMusketman, iChina, tCapital, 12)
-#		utils.makeUnit(iBombard, iChina, tCapital, 5)
-		
-		# India
-		tCapital = tMumbai
-#		utils.makeUnit(iMusketman, iIndia, tCapital, 8)
-#		utils.makeUnit(iBombard, iIndia, tCapital, 5)
-#		utils.makeUnit(iCuirassier, iIndia, tCapital, 3)
-		
-		# Tamils
-		tCapital = tMysore
-#		utils.makeUnit(iMusketman, iTamils, tCapital, 6)
-#		utils.makeUnit(iBombard, iTamils, tCapital, 4)
-		
-		# Persia
-		tCapital = tEsfahan
-#		utils.makeUnit(iIranianQizilbash, iPersia, tCapital, 10)
-#		utils.makeUnit(iBombard, iPersia, tCapital, 4)
-		
-		# Korea
-		tCapital = Areas.getCapital(iKorea)
-#		utils.makeUnit(iMusketman, iKorea, tCapital, 6)
-#		utils.makeUnit(iBombard, iKorea, tCapital, 4)
-		
+
 		# Japan
 		tCapital = Areas.getCapital(iJapan)
-#		utils.makeUnit(iMusketman, iJapan, tCapital, 10)
-#		utils.makeUnit(iBombard, iJapan, tCapital, 4)
 		if utils.getHumanID() != iJapan:
 			utils.makeUnit(iSettler, iJapan, tCapital, 1)
-		
-		# Vikings
-		tCapital = tStockholm
-#		utils.makeUnit(iMusketman, iVikings, tCapital, 8)
-#		utils.makeUnit(iBombard, iVikings, tCapital, 4)
-		
-		# Spain
-		tCapital = Areas.getCapital(iSpain)
-#		utils.makeUnit(iMusketman, iSpain, tCapital, 6)
-#		utils.makeUnit(iSpanishConquistador, iSpain, tCapital, 4)
-#		utils.makeUnit(iBombard, iSpain, tCapital, 2)
-		
-		# France
-		tCapital = Areas.getCapital(iFrance)
-#		utils.makeUnit(iRifleman, iFrance, tCapital, 12)
-#		utils.makeUnit(iCuirassier, iFrance, tCapital, 4)
-#		utils.makeUnit(iFrenchHeavyCannon, iFrance, tCapital, 5)
-		
-		# England
-		tCapital = Areas.getCapital(iEngland)
-#		utils.makeUnit(iEnglishRedcoat, iEngland, tCapital, 8)
-#		utils.makeUnit(iCannon, iEngland, tCapital, 4)
-#		utils.makeUnit(iGalleon, iEngland, tCapital, 4)
-		
-		# Austria
-		tCapital = tVienna
-#		utils.makeUnit(iRifleman, iHolyRome, tCapital, 6)
-#		utils.makeUnit(iCannon, iHolyRome, tCapital, 2)
-		
-		# Russia
-		tCapital = Areas.getCapital(iRussia)
-#		utils.makeUnit(iMusketman, iRussia, tCapital, 8)
-#		utils.makeUnit(iCuirassier, iRussia, tCapital, 4)
-#		utils.makeUnit(iBombard, iRussia, tCapital, 4)
-		
-		# Poland
-		tCapital = tWarsaw
-#		utils.makeUnit(iMusketman, iPoland, tCapital, 4)
-#		utils.makeUnit(iPolishWingedHussar, iPoland, tCapital, 6)
-#		utils.makeUnit(iBombard, iPoland, tCapital, 2)
-		
-		# Portugal
-		tCapital = Areas.getCapital(iPortugal)
-#		utils.makeUnit(iMusketman, iPortugal, tCapital, 6)
-#		utils.makeUnit(iBombard, iPortugal, tCapital, 2)
-#		utils.makeUnit(iGalleon, iPortugal, tCapital, 3)
-		
-		# Mughals
-		tCapital = Areas.getCapital(iMughals)
-#		utils.makeUnit(iMusketman, iMughals, tCapital, 5)
-#		utils.makeUnit(iPikeman, iMughals, tCapital, 2)
-#		utils.makeUnit(iMughalSiegeElephant, iMughals, tCapital, 2)
-		
-		# Turkey
-		tCapital = tIstanbul
-#		utils.makeUnit(iOttomanJanissary, iTurkey, tCapital, 10)
-#		utils.makeUnit(iCuirassier, iTurkey, tCapital, 4)
-#		utils.makeUnit(iBombard, iTurkey, tCapital, 5)
-		
-		# Thailand
-		tCapital = Areas.getCapital(iThailand)
-#		utils.makeUnit(iMusketman, iThailand, tCapital, 4)
-#		utils.makeUnit(iPikeman, iThailand, tCapital, 2)
-#		utils.makeUnit(iThaiChangSuek, iThailand, tCapital, 4)
-#		utils.makeUnit(iBombard, iThailand, tCapital, 2)
-		
-		# Congo
-		tCapital = Areas.getCapital(iCongo)
-#		utils.makeUnit(iSettler, iCongo, tCapital, 1)
-#		utils.makeUnit(iCongolesePombos, iCongo, tCapital, 6)
-#		utils.makeUnit(iCatapult, iCongo, tCapital, 2)
-#		utils.makeUnit(iLongbowman, iCongo, tCapital, 2)
-#		utils.makeUnit(iNativeSlave, iCongo, tCapital, 5)
-		
-		# Netherlands
-		tCapital = Areas.getCapital(iNetherlands)
-#		utils.makeUnit(iRifleman, iNetherlands, tCapital, 5)
-#		utils.makeUnit(iBombard, iNetherlands, tCapital, 2)
-#		utils.makeUnit(iDutchEastIndiaman, iNetherlands, tCapital, 3)
-		
-		# Prussia
-		tCapital = Areas.getCapital(iGermany)
-#		utils.makeUnit(iRifleman, iGermany, tCapital, 8)
-#		utils.makeUnit(iCannon, iGermany, tCapital, 3)
 		
 		for iPlayer in range(iNumPlayers):
 			if tBirth[iPlayer] > utils.getScenarioStartYear() and utils.getHumanID() == iPlayer:
@@ -3673,36 +3440,16 @@ class RiseAndFall:
 		utils.makeUnit(iWorker, iChina, tCapital, 2)
 		
 		tCapital = Areas.getCapital(iJapan)
-#		utils.makeUnit(iSettler, iJapan, tCapital, 3)
-#		utils.makeUnit(iBuddhistMissionary, iJapan, tCapital, 3)
-#		utils.makeUnit(iSwordsman, iJapan, tCapital, 2)
-#		utils.makeUnit(iArcher, iJapan, tCapital, 2)
-		tSeaPlot = self.findSeaPlots(tCapital, 1, iJapan)
-#		if (tSeaPlot):
-#			utils.makeUnit(iWorkboat, iJapan, tSeaPlot, 2)
-
 		if utils.getHumanID() != iJapan:
 			utils.makeUnit(iCrossbowman, iJapan, tCapital, 2)
 			utils.makeUnit(iJapaneseSamurai, iJapan, tCapital, 3)
 
 		tCapital = Areas.getCapital(iVikings)
-#		utils.makeUnit(iSettler, iVikings, tCapital, 1)
-#		utils.makeUnit(iLongbowman, iVikings, tCapital, 2)
-#		utils.makeUnit(iAxeman, iVikings, tCapital, 2)
-#		utils.makeUnit(iScout, iVikings, tCapital, 1)
-#		pVikings.initUnit(iSwordsman, tCapital[0], tCapital[1], UnitAITypes.UNITAI_ATTACK_CITY, DirectionTypes.DIRECTION_SOUTH)
-#		utils.makeUnit(iSwordsman, iVikings, tCapital, 1)
 		tSeaPlot = self.findSeaPlots(tCapital, 1, iVikings)
 		if (tSeaPlot):
-#			utils.makeUnit(iWorkboat, iVikings, tSeaPlot, 1)
-#			pVikings.initUnit(iGalley, tSeaPlot[0], tSeaPlot[1], UnitAITypes.UNITAI_SETTLER_SEA, DirectionTypes.DIRECTION_SOUTH)
 			if utils.getHumanID() == iVikings:
 				utils.makeUnit(iSettler, iVikings, tSeaPlot, 1)
 				utils.makeUnit(iLongbowman, iVikings, tSeaPlot, 1)
-#			pVikings.initUnit(iGalley, tSeaPlot[0], tSeaPlot[1], UnitAITypes.UNITAI_EXPLORE_SEA, DirectionTypes.DIRECTION_SOUTH)
-			#utils.makeUnit(iSettler, iCiv, tSeaPlot, 1)
-#			pVikings.initUnit(iGalley, tSeaPlot[0], tSeaPlot[1], UnitAITypes.UNITAI_EXPLORE_SEA, DirectionTypes.DIRECTION_SOUTH)
-			#utils.makeUnit(iSettler, iCiv, tSeaPlot, 1)
 		# start AI settler and garrison in Denmark and Sweden
 		if utils.getHumanID() != iVikings:
 			utils.makeUnit(iSettler, iVikings, (60, 56), 1)
@@ -3713,23 +3460,7 @@ class RiseAndFall:
 			utils.makeUnit(iSettler, iVikings, tCapital, 1)
 			utils.makeUnit(iLongbowman, iVikings, tCapital, 2)
 
-		tCapital = Areas.getCapital(iByzantium)
-#		utils.makeUnit(iSpearman, iByzantium, tCapital, 2)
-#		utils.makeUnit(iArcher, iByzantium, tCapital, 3)
-#		utils.makeUnit(iByzantineCataphract, iByzantium, tCapital, 1)
-		tSeaPlot = self.findSeaPlots(tCapital, 1, iByzantium)
-#		if tSeaPlot:
-#			utils.makeUnit(iGalley, iByzantium, tSeaPlot, 2)
-#			utils.makeUnit(iTrireme, iByzantium, tSeaPlot, 2)
-
 		tCapital = Areas.getCapital(iKorea)
-#		utils.makeUnit(iSettler, iKorea, tCapital, 2)
-#		utils.makeUnit(iBuddhistMissionary, iKorea, tCapital, 1)
-#		utils.makeUnit(iConfucianMissionary, iKorea, tCapital, 1)
-#		utils.makeUnit(iArcher, iKorea, tCapital, 2)
-#		utils.makeUnit(iAxeman, iKorea, tCapital, 3)
-#		utils.makeUnit(iHorseArcher, iKorea, tCapital, 1)
-
 		if utils.getHumanID() != iKorea:
 			utils.makeUnit(iHeavySwordsman, iKorea, tCapital, 2)
 			
@@ -3744,15 +3475,9 @@ class RiseAndFall:
 	
 		for iPlayer in range(iNumPlayers):
 			tCapital = Areas.getCapital(iPlayer)
-#			if tBirth[iPlayer] == utils.getScenarioStartYear() and iPlayer != iHarappa:
-#				utils.makeUnit(iSettler, iPlayer, tCapital, 1)
-#				utils.makeUnit(iWarrior, iPlayer, tCapital, 1)
 			if iPlayer == iHarappa and (self.getPlayerEnabled(iPlayer) or gc.getPlayer(iPlayer).isHuman()):
 				utils.makeUnit(iHarappanCityBuilder, iPlayer, tCapital, 1)
 				utils.makeUnit(iWarrior, iPlayer, tCapital, 1)
-#			elif gc.getPlayer(iPlayer).isHuman():
-#				utils.makeUnit(iSettler, iPlayer, tCapital, 1)
-#				utils.makeUnit(iWarrior, iPlayer, tCapital, 1)
 			
 		
 		

--- a/PrivateMaps/RFC 1700 AD.CivBeyondSwordWBSave
+++ b/PrivateMaps/RFC 1700 AD.CivBeyondSwordWBSave
@@ -1,3 +1,5 @@
+Platy Builder
+bLoadSpecial=1
 Version=11
 BeginGame
 	Calendar=CALENDAR_DEFAULT
@@ -9,647 +11,752 @@ BeginGame
 	ModPath=Mods\RFC Dawn of Civilization
 EndGame
 BeginTeam
+	TeamID=0, (Egypt)
 EndTeam
 BeginTeam
+	TeamID=1, (China)
 EndTeam
 BeginTeam
+	TeamID=2, (Babylonia)
 EndTeam
 BeginTeam
+	TeamID=3, (Harappa)
 EndTeam
 BeginTeam
+	TeamID=4, (Greece)
 EndTeam
 BeginTeam
+	TeamID=5, (India)
 EndTeam
 BeginTeam
+	TeamID=6, (Phoenicia)
 EndTeam
 BeginTeam
+	TeamID=7, (Polynesia)
 EndTeam
 BeginTeam
+	TeamID=8, (Iran)
 EndTeam
 BeginTeam
+	TeamID=9, (Rome)
 EndTeam
 BeginTeam
+	TeamID=10, (Tamils)
 EndTeam
 BeginTeam
+	TeamID=11, (Ethiopia)
 EndTeam
 BeginTeam
+	TeamID=12, (Korea)
 EndTeam
 BeginTeam
+	TeamID=13, (Colombia)
 EndTeam
 BeginTeam
+	TeamID=14, (Byzantium)
 EndTeam
 BeginTeam
+	TeamID=15, (Japan)
 EndTeam
 BeginTeam
+	TeamID=16, (Vikings)
 EndTeam
 BeginTeam
+	TeamID=17, (Arabia)
 EndTeam
 BeginTeam
+	TeamID=18, (Tibet)
 EndTeam
 BeginTeam
+	TeamID=19, (Khmer)
 EndTeam
 BeginTeam
+	TeamID=20, (Indonesia)
 EndTeam
 BeginTeam
+	TeamID=21, (Moors)
 EndTeam
 BeginTeam
+	TeamID=22, (Spain)
 EndTeam
 BeginTeam
+	TeamID=23, (France)
 EndTeam
 BeginTeam
+	TeamID=24, (England)
 EndTeam
 BeginTeam
+	TeamID=25, (HolyRome)
 EndTeam
 BeginTeam
+	TeamID=26, (Russia)
 EndTeam
 BeginTeam
+	TeamID=27, (Mali)
 EndTeam
 BeginTeam
+	TeamID=28, (Poland)
 EndTeam
 BeginTeam
+	TeamID=29, (Portugal)
 EndTeam
 BeginTeam
+	TeamID=30, (Inca)
 EndTeam
 BeginTeam
+	TeamID=31, (Italy)
 EndTeam
 BeginTeam
+	TeamID=32, (Mongols)
 EndTeam
 BeginTeam
+	TeamID=33, (Mexico)
 EndTeam
 BeginTeam
+	TeamID=34, (Mughals)
 EndTeam
 BeginTeam
+	TeamID=35, (Turkey)
 EndTeam
 BeginTeam
+	TeamID=36, (Thailand)
 EndTeam
 BeginTeam
+	TeamID=37, (Congo)
 EndTeam
 BeginTeam
+	TeamID=38, (Netherlands)
 EndTeam
 BeginTeam
+	TeamID=39, (Germany)
 EndTeam
 BeginTeam
+	TeamID=40, (America)
 EndTeam
 BeginTeam
+	TeamID=41, (Argentina)
 EndTeam
 BeginTeam
+	TeamID=42, (Brazil)
 EndTeam
 BeginTeam
+	TeamID=43, (Canada)
 EndTeam
 BeginTeam
+	TeamID=44, (Independent)
 EndTeam
 BeginTeam
+	TeamID=45, (Independent2)
 EndTeam
 BeginTeam
+	TeamID=46, (Native)
 EndTeam
 BeginTeam
+	TeamID=47, (Celtia)
 EndTeam
 BeginTeam
+	TeamID=48, (Seljuks)
+EndTeam
+BeginTeam
+	TeamID=49, (Barbarian)
 EndTeam
 BeginPlayer
+	Team=0
 	LeaderType=LEADER_RAMESSES
 	CivType=CIVILIZATION_EGYPT
-	Team=0
 	PlayableCiv=0
-	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_PANTHEON
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=1
 	LeaderType=LEADER_HONGWU
 	LeaderName=TXT_KEY_LEADER_KANGXI
 	CivType=CIVILIZATION_CHINA
-	Team=1
 	PlayableCiv=1
+	StartingGold=300
+	StateReligion=RELIGION_CONFUCIANISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_CONFUCIANISM
+	AttitudePlayer=12, AttitudeExtra=2, (Korea)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=2
 	LeaderType=LEADER_HAMMURABI
 	CivType=CIVILIZATION_BABYLONIA
-	Team=2
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=3
 	LeaderType=LEADER_VATAVELLI
 	CivType=CIVILIZATION_HARAPPANS
-	Team=3
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=4
 	LeaderType=LEADER_PERICLES
 	CivType=CIVILIZATION_GREECE
-	Team=4
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=5
 	LeaderType=LEADER_SHIVAJI
 	CivType=CIVILIZATION_INDIA
-	Team=5
 	PlayableCiv=1
+	StartingGold=400
+	StateReligion=RELIGION_HINDUISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
+	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
-	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE,
-	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS,
+	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_HINDUISM
+	AttitudePlayer=34, AttitudeExtra=-2, (Mughals)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=6
 	LeaderType=LEADER_HANNIBAL
 	CivType=CIVILIZATION_PHOENICIA
-	Team=6
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=7
 	LeaderType=LEADER_AHOEITU
 	CivType=CIVILIZATION_POLYNESIA
-	Team=7
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=8
 	LeaderType=LEADER_ABBAS
 	CivType=CIVILIZATION_IRAN
-	Team=8
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_FANATICISM
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ISLAM
+	AttitudePlayer=34, AttitudeExtra=-2, (Mughals)
+	AttitudePlayer=35, AttitudeExtra=-4, (Turkey)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=9
 	LeaderType=LEADER_AUGUSTUS
 	CivType=CIVILIZATION_ROME
-	Team=9
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=10
 	LeaderType=LEADER_KRISHNA_DEVA_RAYA
 	LeaderName=TXT_KEY_LEADER_TIPU_SULTAN
 	CivType=CIVILIZATION_TAMILS
-	Team=10
 	PlayableCiv=1
+	StartingGold=400
+	StateReligion=RELIGION_HINDUISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
+	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
-	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM,
-	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM,
+	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_HINDUISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=11
 	LeaderType=LEADER_ZARA_YAQOB
 	CivType=CIVILIZATION_ETHIOPIA
-	Team=11
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=12
 	LeaderType=LEADER_SEJONG
 	CivType=CIVILIZATION_KOREA
-	Team=12
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_CONFUCIANISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_CONFUCIANISM
+	AttitudePlayer=1, AttitudeExtra=2, (China)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=13
 	LeaderType=LEADER_PACAL
 	CivType=CIVILIZATION_MAYA
-	Team=13
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=14
 	LeaderType=LEADER_JUSTINIAN
 	CivType=CIVILIZATION_BYZANTIUM
-	Team=14
 	PlayableCiv=0
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=15
 	LeaderType=LEADER_TOKUGAWA
 	CivType=CIVILIZATION_JAPAN
-	Team=15
 	PlayableCiv=1
+	StartingGold=400
+	StateReligion=RELIGION_BUDDHISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_BUDDHISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=16
 	LeaderType=LEADER_GUSTAV
-	CivType=CIVILIZATION_VIKING
 	CivDesc=TXT_KEY_CIV_SWEDEN_DESC
 	CivShortDesc=TXT_KEY_CIV_SWEDEN_SHORT_DESC
 	CivAdjective=TXT_KEY_CIV_SWEDEN_ADJECTIVE
-	Team=16
+	CivType=CIVILIZATION_VIKING
 	PlayableCiv=1
+	StartingGold=150
+	StateReligion=RELIGION_PROTESTANTISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_PROTESTANTISM
+	AttitudePlayer=26, AttitudeExtra=-2, (Russia)
+	AttitudePlayer=35, AttitudeExtra=-2, (Turkey)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=17
 	LeaderType=LEADER_SALADIN
 	CivType=CIVILIZATION_ARABIA
-	Team=17
 	PlayableCiv=0
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=18
 	LeaderType=LEADER_LOBSANG_GYATSO
 	CivType=CIVILIZATION_TIBET
-	Team=18
 	PlayableCiv=0
-	StateReligion=RELIGION_BUDDHISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=19
 	LeaderType=LEADER_SURYAVARMAN
 	CivType=CIVILIZATION_KHMER
-	Team=19
 	PlayableCiv=0
-	StateReligion=RELIGION_HINDUISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=20
 	LeaderType=LEADER_HAYAM_WURUK
 	CivType=CIVILIZATION_INDONESIA
-	Team=20
 	PlayableCiv=0
-	StateReligion=RELIGION_BUDDHISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=21
 	LeaderType=LEADER_RAHMAN
 	CivType=CIVILIZATION_MOORS
-	Team=21
 	PlayableCiv=0
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=22
 	LeaderType=LEADER_FILIPE
 	CivType=CIVILIZATION_SPAIN
-	Team=22
 	PlayableCiv=1
+	StartingGold=400
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_CATHOLICISM
+	AttitudePlayer=29, AttitudeExtra=2, (Portugal)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=23
 	LeaderType=LEADER_LOUIS_XIV
 	CivType=CIVILIZATION_FRANCE
-	Team=23
 	PlayableCiv=1
+	StartingGold=400
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_CATHOLICISM
+	AttitudePlayer=24, AttitudeExtra=-4, (England)
+	AttitudePlayer=35, AttitudeExtra=-2, (Turkey)
+	AttitudePlayer=38, AttitudeExtra=2, (Netherlands)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=24
 	LeaderType=LEADER_VICTORIA
 	CivType=CIVILIZATION_ENGLAND
-	Team=24
 	PlayableCiv=1
+	StartingGold=600
+	StateReligion=RELIGION_PROTESTANTISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_NAVAL_SUPREMACY
-	StateReligion=RELIGION_PROTESTANTISM
+	AttitudePlayer=23, AttitudeExtra=-4, (France)
+	AttitudePlayer=29, AttitudeExtra=2, (Portugal)
+	AttitudePlayer=34, AttitudeExtra=-2, (Mughals)
+	AttitudePlayer=35, AttitudeExtra=-2, (Turkey)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=25
 	LeaderType=LEADER_FRANCIS
-	CivType=CIVILIZATION_HOLY_ROMAN
 	CivDesc=TXT_KEY_CIV_AUSTRIA_DESC
 	CivShortDesc=TXT_KEY_CIV_AUSTRIA_SHORT_DESC
 	CivAdjective=TXT_KEY_CIV_AUSTRIA_ADJECTIVE
-	Team=25
+	CivType=CIVILIZATION_HOLY_ROMAN
 	PlayableCiv=1
+	StartingGold=150
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_CATHOLICISM
+	AttitudePlayer=35, AttitudeExtra=-4, (Turkey)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=26
 	LeaderType=LEADER_PETER
 	CivType=CIVILIZATION_RUSSIA
-	Team=26
 	PlayableCiv=1
+	StartingGold=350
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ORTHODOXY
+	AttitudePlayer=16, AttitudeExtra=-2, (Vikings)
+	AttitudePlayer=35, AttitudeExtra=-4, (Turkey)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=27
 	LeaderType=LEADER_MANSA_MUSA
 	CivType=CIVILIZATION_MALI
-	Team=27
 	PlayableCiv=0
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=28
 	LeaderType=LEADER_SOBIESKI
 	CivType=CIVILIZATION_POLAND
-	Team=28
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_REPUBLIC
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=29
 	LeaderType=LEADER_JOAO
 	CivType=CIVILIZATION_PORTUGAL
-	Team=29
 	PlayableCiv=1
+	StartingGold=450
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_NAVAL_SUPREMACY
-	StateReligion=RELIGION_CATHOLICISM
+	AttitudePlayer=22, AttitudeExtra=2, (Spain)
+	AttitudePlayer=24, AttitudeExtra=2, (England)
+	AttitudePlayer=38, AttitudeExtra=-2, (Netherlands)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=30
 	LeaderType=LEADER_HUAYNA_CAPAC
 	CivType=CIVILIZATION_INCA
-	Team=30
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=31
 	LeaderType=LEADER_CAVOUR
 	CivType=CIVILIZATION_ITALY
-	Team=31
 	PlayableCiv=0
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=32
 	LeaderType=LEADER_GENGHIS_KHAN
 	CivType=CIVILIZATION_MONGOL
-	Team=32
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=33
 	LeaderType=LEADER_MONTEZUMA
 	CivType=CIVILIZATION_AZTEC
-	Team=33
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=34
 	LeaderType=LEADER_AKBAR
 	CivType=CIVILIZATION_MUGHALS
-	Team=34
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
+	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
-	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ISLAM
+	AttitudePlayer=5, AttitudeExtra=-2, (India)
+	AttitudePlayer=8, AttitudeExtra=-2, (Iran)
+	AttitudePlayer=24, AttitudeExtra=-2, (England)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=35
 	LeaderType=LEADER_SULEIMAN
 	CivType=CIVILIZATION_OTTOMAN
-	Team=35
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ISLAM
+	AttitudePlayer=8, AttitudeExtra=-4, (Iran)
+	AttitudePlayer=16, AttitudeExtra=-2, (Vikings)
+	AttitudePlayer=23, AttitudeExtra=-2, (France)
+	AttitudePlayer=24, AttitudeExtra=-2, (England)
+	AttitudePlayer=25, AttitudeExtra=-4, (Holy Rome)
+	AttitudePlayer=26, AttitudeExtra=-4, (Russia)
+	AttitudePlayer=38, AttitudeExtra=-2, (Netherlands)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=36
 	LeaderType=LEADER_NARESUAN
 	CivType=CIVILIZATION_THAILAND
-	Team=36
 	PlayableCiv=1
+	StartingGold=300
+	StateReligion=RELIGION_BUDDHISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_BUDDHISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=37
 	LeaderType=LEADER_MBEMBA
 	CivType=CIVILIZATION_CONGO
-	Team=37
 	PlayableCiv=1
+	StartingGold=300
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
+	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_SUBSISTENCE
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
-	StateReligion=RELIGION_CATHOLICISM
+	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_MILITIA
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=38
 	LeaderType=LEADER_WILLIAM_III
 	CivType=CIVILIZATION_NETHERLANDS
-	Team=38
 	PlayableCiv=1
+	StartingGold=800
+	StateReligion=RELIGION_PROTESTANTISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_REPUBLIC
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_NAVAL_SUPREMACY
-	StateReligion=RELIGION_PROTESTANTISM
+	AttitudePlayer=23, AttitudeExtra=2, (France)
+	AttitudePlayer=29, AttitudeExtra=-2, (Portugal)
+	AttitudePlayer=35, AttitudeExtra=-2, (Turkey)
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=39
 	LeaderType=LEADER_FREDERICK
 	CivType=CIVILIZATION_GERMANY
-	Team=39
 	PlayableCiv=1
+	StartingGold=800
+	StateReligion=RELIGION_PROTESTANTISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_PROTESTANTISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=40
 	LeaderType=LEADER_WASHINGTON
 	CivType=CIVILIZATION_AMERICA
-	Team=40
 	PlayableCiv=1
+	StartingGold=1500
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_REPUBLIC
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_SECULARISM
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_PROTESTANTISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=41
 	LeaderType=LEADER_SAN_MARTIN
 	CivType=CIVILIZATION_ARGENTINA
-	Team=41
 	PlayableCiv=1
+	StartingGold=1200
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_AUTOCRACY
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_SECULARISM
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=42
 	LeaderType=LEADER_DOM_PEDRO
 	CivType=CIVILIZATION_BRAZIL
-	Team=42
 	PlayableCiv=1
+	StartingGold=1600
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=43
 	LeaderType=LEADER_MACDONALD
 	CivType=CIVILIZATION_CANADA
-	Team=43
 	PlayableCiv=1
+	StartingGold=1000
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_PROTESTANTISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=44
 	LeaderType=LEADER_INDEPENDENT
 	CivType=CIVILIZATION_INDEPENDENT
-	Team=44
 	PlayableCiv=0
 	MinorNationStatus=1
+	StartingGold=50
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=45
 	LeaderType=LEADER_INDEPENDENT
 	CivType=CIVILIZATION_INDEPENDENT2
-	Team=45
 	PlayableCiv=0
 	MinorNationStatus=1
+	StartingGold=50
 	Handicap=HANDICAP_REGENT
-	StateReligion=RELIGION_CATHOLICISM
 EndPlayer
 BeginPlayer
+	Team=46
 	LeaderType=LEADER_NATIVE
 	CivType=CIVILIZATION_NATIVE
-	Team=46
 	PlayableCiv=0
 	MinorNationStatus=1
+	StartingGold=100
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=47
 	LeaderType=LEADER_JUSTINIAN
 	CivType=CIVILIZATION_BYZANTIUM
-	StateReligion=RELIGION_CATHOLICISM
-	Team=47
 	PlayableCiv=0
 	MinorNationStatus=1
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=48
 	LeaderType=LEADER_ALP
 	CivType=CIVILIZATION_SELJUK
-	StateReligion=RELIGION_ISLAM
-	Team=48
 	PlayableCiv=0
 	MinorNationStatus=1
 	Handicap=HANDICAP_REGENT
 EndPlayer
-
+BeginPlayer
+	Team=49
+	LeaderType=LEADER_BARBARIAN
+	CivType=CIVILIZATION_BARBARIAN
+	PlayableCiv=0
+	Handicap=HANDICAP_REGENT
+EndPlayer
 BeginMap
 	grid width=124
 	grid height=68
-	wrap X=1
-	wrap Y=0
 	top latitude=90
 	bottom latitude=-90
+	wrap X=1
+	wrap Y=0
 	world size=WORLDSIZE_HUGE
 	climate=CLIMATE_TEMPERATE
 	sealevel=SEALEVEL_MEDIUM
@@ -6298,14 +6405,10 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Hermosillo
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -6694,14 +6797,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Guadalajara
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -7480,14 +7579,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Ciudad de M&#233;xico
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -7524,14 +7619,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Monterrey
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -7948,8 +8039,8 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
@@ -9095,9 +9186,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=22,y=33
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=22,24,44,
@@ -9169,28 +9260,16 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Nouvelle Orl&#233;ans
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -9558,14 +9637,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Ciudad de Guatemala
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -9595,8 +9670,8 @@ EndPlot
 BeginPlot
 	x=23,y=36
 	BonusType=BONUS_DYE
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -9608,14 +9683,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Ciudad Real
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -9985,14 +10056,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Quito
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -10497,8 +10564,8 @@ EndPlot
 BeginPlot
 	x=25,y=38
 	BonusType=BONUS_TOBACCO
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=22,23,24,44,45,
@@ -10535,14 +10602,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Charles Town
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -10835,14 +10898,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Lima
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -10886,9 +10945,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=26,y=27
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_COFFEE
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -10970,23 +11029,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=La Habana
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -11335,8 +11384,8 @@ EndPlot
 BeginPlot
 	x=27,y=24
 	BonusType=BONUS_SILVER
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_MINE
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -11380,14 +11429,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Bogot&#225;
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -11401,18 +11446,18 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=27,y=30
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_COFFEE
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=22,45,
 EndPlot
 BeginPlot
 	x=27,y=31
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=22,24,45,
@@ -11551,28 +11596,16 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=York
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -12172,14 +12205,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Santiago de Chile
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -12329,9 +12358,9 @@ BeginPlot
 	x=29,y=30
 	isNOfRiver
 	RiverWEDirection=1
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_COFFEE
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -12382,14 +12411,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Port-au-Prince
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -12825,14 +12850,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Caracas
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -12951,21 +12972,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=New York
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -13012,28 +13025,16 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Montr&#233;al
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -13260,14 +13261,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=La Paz
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -13494,14 +13491,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Boston
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -13866,19 +13859,14 @@ EndPlot
 BeginPlot
 	x=32,y=37
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=San Juan
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -14210,8 +14198,8 @@ EndPlot
 BeginPlot
 	x=33,y=20
 	BonusType=BONUS_SILVER
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_MINE
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -14322,14 +14310,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Bridgetown
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -14613,23 +14597,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Buenos Aires
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -14791,14 +14765,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Georgetown
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -15552,14 +15522,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Montevideo
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -15681,8 +15647,8 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -15850,14 +15816,10 @@ BeginPlot
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=St. John's
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -16145,14 +16107,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Cayenne
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -16492,14 +16450,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=S&#227;o Paulo
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -16571,8 +16525,8 @@ EndPlot
 BeginPlot
 	x=38,y=25
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=23,29,44,
@@ -16583,14 +16537,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Bel&#233;m
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -17011,9 +16961,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=39,y=26
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
@@ -17773,37 +17723,25 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Rio de Janeiro
 		CityPopulation=5
-		BuildingType=BUILDING_ADMINISTRATIVE_CENTER
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_LIGHTHOUSE
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_COURTHOUSE
+		BuildingType=BUILDING_ADMINISTRATIVE_CENTER
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
 		Player29Culture=100
@@ -18255,14 +18193,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Recife
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -18661,9 +18595,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=43,y=23
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
@@ -19110,25 +19044,25 @@ BeginPlot
 	x=44,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=44,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=44,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=44,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=44,y=34
@@ -19190,14 +19124,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Ponta Delgada
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -19522,43 +19452,43 @@ BeginPlot
 	x=45,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=36
@@ -19726,14 +19656,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Reykjavik
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -19938,44 +19864,44 @@ BeginPlot
 	x=46,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,38,
+	TeamReveal=23,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=35
 	FeatureType=FEATURE_ISLANDS, FeatureVariety=0
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,29,
+	TeamReveal=22,23,29,
 EndPlot
 BeginPlot
 	x=46,y=36
@@ -20327,43 +20253,43 @@ BeginPlot
 	x=47,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,45,
+	TeamReveal=22,23,24,29,38,45,
 EndPlot
 BeginPlot
 	x=47,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,45,
+	TeamReveal=22,23,24,29,38,45,
 EndPlot
 BeginPlot
 	x=47,y=31
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=47,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=47,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=47,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=22,23,24,29,38,44,
 EndPlot
 BeginPlot
 	x=47,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=22,23,24,29,38,44,
 EndPlot
 BeginPlot
 	x=47,y=36
@@ -20386,14 +20312,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Funchal
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -20737,20 +20659,20 @@ BeginPlot
 	x=48,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,45,
+	TeamReveal=22,23,24,29,38,45,
 EndPlot
 BeginPlot
 	x=48,y=30
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,38,45,
+	TeamReveal=22,23,24,29,38,45,
 EndPlot
 BeginPlot
 	x=48,y=31
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,38,45,
+	TeamReveal=22,23,24,29,38,45,
 EndPlot
 BeginPlot
 	x=48,y=32
@@ -20760,14 +20682,10 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Saint-Louis du S&#233;n&#233;gal
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -20778,26 +20696,26 @@ BeginPlot
 		ReligionType=RELIGION_CATHOLICISM
 		Player23Culture=50
 	EndCity
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=48,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=22,23,24,29,38,44,
 EndPlot
 BeginPlot
 	x=48,y=34
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=22,23,24,29,38,44,
 EndPlot
 BeginPlot
 	x=48,y=35
 	FeatureType=FEATURE_CAPE, FeatureVariety=0
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=22,23,24,29,38,44,
 EndPlot
 BeginPlot
 	x=48,y=36
@@ -20865,6 +20783,7 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,22,23,24,29,38,45,
+	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=48,y=46
@@ -21237,6 +21156,7 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,22,23,24,29,38,44,45,
+	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=49,y=41
@@ -21260,8 +21180,41 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=29, (Portugal)
+	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Lisboa
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -21310,14 +21263,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=La Coru&#241;a
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -21394,14 +21343,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Dublin
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -21642,7 +21587,7 @@ BeginPlot
 	x=50,y=29
 	TerrainType=TERRAIN_PLAINS
 	PlotType=0
-	TeamReveal=22,24,38,44,45,
+	TeamReveal=22,23,24,38,44,45,
 EndPlot
 BeginPlot
 	x=50,y=30
@@ -21684,7 +21629,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	TeamReveal=22,29,44,45,
+	TeamReveal=22,23,29,44,45,
 EndPlot
 BeginPlot
 	x=50,y=36
@@ -21734,6 +21679,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,22,23,24,29,38,45,
+	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=50,y=43
@@ -21745,6 +21691,7 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=16,22,23,24,29,38,45,
+	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=50,y=44
@@ -21753,6 +21700,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,29,38,45,
+	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=50,y=45
@@ -22062,21 +22010,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Djenne
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -22098,19 +22038,19 @@ BeginPlot
 	x=51,y=31
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=45,
+	TeamReveal=23,45,
 EndPlot
 BeginPlot
 	x=51,y=32
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=45,
+	TeamReveal=23,45,
 EndPlot
 BeginPlot
 	x=51,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=44,45,
+	TeamReveal=23,44,45,
 EndPlot
 BeginPlot
 	x=51,y=34
@@ -22122,7 +22062,7 @@ BeginPlot
 	x=51,y=35
 	TerrainType=TERRAIN_DESERT
 	PlotType=0
-	TeamReveal=29,44,45,
+	TeamReveal=23,29,44,45,
 EndPlot
 BeginPlot
 	x=51,y=36
@@ -22137,21 +22077,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Marrakus
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -22194,50 +22126,22 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Sevilla
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -22718,8 +22622,44 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_SPANISH_CONQUISTADOR, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SPANISH_CONQUISTADOR, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SPANISH_CONQUISTADOR, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SPANISH_CONQUISTADOR, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=22, (Spain)
+	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Madrid
 		CityPopulation=8
 		BuildingType=BUILDING_PALACE
@@ -22858,14 +22798,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Edinburgh
 		CityPopulation=7
 		BuildingType=BUILDING_BARRACKS
@@ -23087,8 +23023,8 @@ EndPlot
 BeginPlot
 	x=53,y=28
 	BonusType=BONUS_GOLD
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_MINE
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -23116,28 +23052,16 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Timbuktu
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -23273,42 +23197,22 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Bordeaux
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -23372,8 +23276,56 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=London
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -23385,7 +23337,6 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CUSTOMS_HOUSE
 		BuildingType=BUILDING_FORGE
-		BuildingType=BUILDING_ACADEMY
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_UNIVERSITY
 		BuildingType=BUILDING_THEATRE
@@ -23393,6 +23344,7 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_ENGLISH_ROYAL_EXCHANGE
 		BuildingType=BUILDING_COURTHOUSE
+		BuildingType=BUILDING_ACADEMY
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		BuildingType=BUILDING_PROTESTANT_CATHEDRAL
 		BuildingType=BUILDING_TRADING_COMPANY
@@ -23630,14 +23582,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Elmina
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -23645,8 +23593,8 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
-		ReligionType=RELIGION_PROTESTANTISM
 		ReligionType=RELIGION_CATHOLICISM
+		ReligionType=RELIGION_PROTESTANTISM
 		Player38Culture=50
 	EndCity
 	TeamReveal=22,24,29,38,45,
@@ -23750,14 +23698,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Wahran
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -24242,14 +24186,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Barcelona
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -24316,8 +24256,71 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=23, (France)
+	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Paris
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -24326,7 +24329,6 @@ BeginPlot
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_AQUEDUCT
 		BuildingType=BUILDING_FORGE
-		BuildingType=BUILDING_ACADEMY
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_UNIVERSITY
 		BuildingType=BUILDING_AMPHITHEATRE
@@ -24335,6 +24337,7 @@ BeginPlot
 		BuildingType=BUILDING_BANK
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_FRENCH_SALON
+		BuildingType=BUILDING_ACADEMY
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_CATHEDRAL
 		BuildingType=BUILDING_TRADING_COMPANY
@@ -24623,21 +24626,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Gao
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -24763,14 +24758,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Marseille
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -25272,8 +25263,38 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=38, (Netherlands)
+	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Amsterdam
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -25293,12 +25314,12 @@ BeginPlot
 		BuildingType=BUILDING_BANK
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_DUTCH_DIKE
-		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
+		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		BuildingType=BUILDING_TRADING_COMPANY
 		ReligionType=RELIGION_JUDAISM
-		ReligionType=RELIGION_PROTESTANTISM
 		ReligionType=RELIGION_CATHOLICISM
+		ReligionType=RELIGION_PROTESTANTISM
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		Player38Culture=250
@@ -25623,14 +25644,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Tunus
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -25715,6 +25732,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,38,39,44,45,
+	Player39Culture=100, (Germany)
 EndPlot
 BeginPlot
 	x=58,y=50
@@ -25740,6 +25758,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,22,23,24,25,38,39,45,
+	Player38Culture=100, (Netherlands)
 EndPlot
 BeginPlot
 	x=58,y=53
@@ -25748,6 +25767,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,22,23,24,25,38,39,44,45,
+	Player38Culture=100, (Netherlands)
 EndPlot
 BeginPlot
 	x=58,y=54
@@ -25801,21 +25821,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Bergen
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -26028,15 +26040,11 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
-		CityName=TXT_KEY_CITY_NAME_LAGOS
+		CityOwner=29, (Portugal)
+		CityName=Lagos
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
@@ -26073,21 +26081,13 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Ngazargamu
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -26217,21 +26217,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
 	EndUnit
 	BeginCity
-		CityOwner=25
+		CityOwner=25, (Holy Rome)
 		CityName=Mailand
 		CityPopulation=7
 		BuildingType=BUILDING_BARRACKS
@@ -26270,6 +26262,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,38,39,44,45,
+	Player39Culture=100, (Germany)
 EndPlot
 BeginPlot
 	x=59,y=50
@@ -26287,21 +26280,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
 	EndUnit
 	BeginCity
-		CityOwner=39
+		CityOwner=39, (Germany)
 		CityName=Frankfurt
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -26314,15 +26299,15 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_BANK
 		BuildingType=BUILDING_COURTHOUSE
+		BuildingType=BUILDING_MILITARY_ACADEMY
+		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		BuildingType=BUILDING_PROTESTANT_CATHEDRAL
 		BuildingType=BUILDING_PROTESTANT_SHRINE
-		BuildingType=BUILDING_CATHOLIC_TEMPLE
-		BuildingType=BUILDING_MILITARY_ACADEMY
-		ReligionType=RELIGION_PROTESTANTISM
-		HolyCityReligionType=RELIGION_PROTESTANTISM
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
+		ReligionType=RELIGION_PROTESTANTISM
+		HolyCityReligionType=RELIGION_PROTESTANTISM
 		Player39Culture=100
 	EndCity
 	TeamReveal=16,22,23,24,25,38,39,45,
@@ -26355,35 +26340,19 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=39, (Germany)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=39, (Germany)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
 	EndUnit
 	BeginCity
-		CityOwner=39
+		CityOwner=39, (Germany)
 		CityName=Hamburg
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -26397,9 +26366,8 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
-		ReligionType=RELIGION_PROTESTANTISM
 		ReligionType=RELIGION_CATHOLICISM
-		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
+		ReligionType=RELIGION_PROTESTANTISM
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		Player39Culture=100
 	EndCity
@@ -26779,35 +26747,19 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Roma
 		CityPopulation=8
 		BuildingType=BUILDING_WALLS
@@ -26875,6 +26827,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,38,39,44,45,
+	Player39Culture=100, (Germany)
 EndPlot
 BeginPlot
 	x=60,y=50
@@ -26934,35 +26887,19 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_RIFLEMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=K&#248;benhavn
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -26999,28 +26936,16 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Oslo
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -27234,8 +27159,8 @@ EndPlot
 BeginPlot
 	x=61,y=22
 	BonusType=BONUS_COTTON
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -27343,14 +27268,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Trablus
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -27558,21 +27479,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Trondheim
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -27735,8 +27648,56 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CATAPULT, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CATAPULT, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=37, (Congo)
+	EndUnit
 	BeginCity
-		CityOwner=37
+		CityOwner=37, (Congo)
 		CityName=Mbanza Kongo
 		CityPopulation=8
 		BuildingType=BUILDING_PALACE
@@ -27908,14 +27869,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
 	EndUnit
 	BeginCity
-		CityOwner=25
+		CityOwner=25, (Holy Rome)
 		CityName=Neapel
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -27984,8 +27941,32 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=25, (Holy Rome)
+	EndUnit
 	BeginCity
-		CityOwner=25
+		CityOwner=25, (Holy Rome)
 		CityName=Wien
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -28001,10 +27982,10 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_BANK
 		BuildingType=BUILDING_HOLY_ROMAN_RATHAUS
+		BuildingType=BUILDING_MILITARY_ACADEMY
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_CATHEDRAL
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
-		BuildingType=BUILDING_MILITARY_ACADEMY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
 		Player25Culture=250
@@ -28027,6 +28008,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,26,28,38,39,45,
+	Player25Culture=100, (Holy Rome)
 EndPlot
 BeginPlot
 	x=62,y=52
@@ -28041,8 +28023,41 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=39, (Germany)
+	EndUnit
 	BeginCity
-		CityOwner=39
+		CityOwner=39, (Germany)
 		CityName=Berlin
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -28225,21 +28240,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Kaapstad
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -28597,8 +28604,44 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=16, (Vikings)
+	EndUnit
 	BeginCity
-		CityOwner=16
+		CityOwner=16, (Vikings)
 		CityName=Stockholm
 		CityPopulation=8
 		BuildingType=BUILDING_PALACE
@@ -28802,9 +28845,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=64,y=20
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
@@ -29050,6 +29093,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,23,25,26,28,38,39,44,45,
+	Player28Culture=100, (Poland)
 EndPlot
 BeginPlot
 	x=64,y=54
@@ -29450,21 +29494,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Belgrad
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -29508,21 +29544,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
 	EndUnit
 	BeginCity
-		CityOwner=25
+		CityOwner=25, (Holy Rome)
 		CityName=Budapest
 		CityPopulation=8
 		BuildingType=BUILDING_BARRACKS
@@ -29571,8 +29599,44 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=28, (Poland)
+	EndUnit
 	BeginCity
-		CityOwner=28
+		CityOwner=28, (Poland)
 		CityName=Warszawa
 		CityPopulation=8
 		BuildingType=BUILDING_PALACE
@@ -29611,14 +29675,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
 	EndUnit
 	BeginCity
-		CityOwner=39
+		CityOwner=39, (Germany)
 		CityName=K&#246;nigsberg
 		CityPopulation=4
 		BuildingType=BUILDING_BARRACKS
@@ -29686,14 +29746,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
 	EndUnit
 	BeginCity
-		CityOwner=16
+		CityOwner=16, (Vikings)
 		CityName=Lule&#229;
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -30147,6 +30203,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,25,26,28,39,45,
+	Player28Culture=100, (Poland)
 EndPlot
 BeginPlot
 	x=66,y=56
@@ -30486,14 +30543,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Iskenderiye
 		CityPopulation=10
 		BuildingType=BUILDING_GRANARY
@@ -30509,8 +30562,8 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_CATHEDRAL
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
-		BuildingType=BUILDING_GREAT_LIBRARY
 		BuildingType=BUILDING_GREAT_LIGHTHOUSE
+		BuildingType=BUILDING_GREAT_LIBRARY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
@@ -30538,8 +30591,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=67,y=40
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_CLAM
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=35,44,
@@ -30550,14 +30603,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Atina
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -30678,21 +30727,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=28
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=28
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
 	EndUnit
 	BeginCity
-		CityOwner=28
+		CityOwner=28, (Poland)
 		CityName=Wilno
 		CityPopulation=5
 		BuildingType=BUILDING_BARRACKS
@@ -30726,12 +30767,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,26,28,39,
+	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=67,y=58
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,26,28,39,45,
+	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=67,y=59
@@ -30741,14 +30784,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
 	EndUnit
 	BeginCity
-		CityOwner=16
+		CityOwner=16, (Vikings)
 		CityName=Helsingfors
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -31150,8 +31189,65 @@ BeginPlot
 	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
+	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Kostantiniyye
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -31170,15 +31266,15 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_COURTHOUSE
+		BuildingType=BUILDING_MILITARY_ACADEMY
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_CATHEDRAL
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
-		BuildingType=BUILDING_MILITARY_ACADEMY
 		BuildingType=BUILDING_THEODOSIAN_WALLS
 		BuildingType=BUILDING_HAGIA_SOPHIA
-		BuildingType=BUILDING_TOPKAPI_PALACE
 		BuildingType=BUILDING_BLUE_MOSQUE
+		BuildingType=BUILDING_TOPKAPI_PALACE
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
@@ -31283,6 +31379,7 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,26,28,39,45,
+	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=68,y=59
@@ -31290,6 +31387,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,26,28,39,45,
+	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=68,y=60
@@ -31558,14 +31656,10 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=El-Uqsur
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -31604,14 +31698,10 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=El-Kahire
 		CityPopulation=7
 		BuildingType=BUILDING_BARRACKS
@@ -31624,8 +31714,8 @@ BeginPlot
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
-		BuildingType=BUILDING_PYRAMIDS
 		BuildingType=BUILDING_GREAT_SPHINX
+		BuildingType=BUILDING_PYRAMIDS
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
@@ -31755,21 +31845,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Kiev
 		CityPopulation=8
 		BuildingType=BUILDING_BARRACKS
@@ -31809,6 +31891,7 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=16,26,28,39,45,
+	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=69,y=55
@@ -31823,6 +31906,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,26,28,39,45,
+	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=69,y=57
@@ -31839,21 +31923,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Sankt-Peterburg
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -32337,7 +32413,7 @@ BeginPlot
 	x=70,y=58
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=16,26,39,45,
+	TeamReveal=16,26,28,39,45,
 EndPlot
 BeginPlot
 	x=70,y=59
@@ -32347,7 +32423,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=16,26,39,45,
+	TeamReveal=16,26,28,39,45,
 EndPlot
 BeginPlot
 	x=70,y=60
@@ -32491,14 +32567,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Mo&#231;ambique
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -32547,21 +32619,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Mombasa
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -32734,14 +32798,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Ankara
 		CityPopulation=5
 		BuildingType=BUILDING_BARRACKS
@@ -32850,7 +32910,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=16,26,
+	TeamReveal=16,26,28,
 EndPlot
 BeginPlot
 	x=71,y=57
@@ -32865,13 +32925,13 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_VILLAGE
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=16,26,
+	TeamReveal=16,26,28,
 EndPlot
 BeginPlot
 	x=71,y=59
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=16,26,
+	TeamReveal=16,26,28,
 EndPlot
 BeginPlot
 	x=71,y=60
@@ -33108,21 +33168,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Gondar
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -33371,14 +33423,10 @@ BeginPlot
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Arkhangelsk
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -33676,14 +33724,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Kud&#252;s
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -33693,17 +33737,19 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_MARKET
-		BuildingType=BUILDING_CATHOLIC_TEMPLE
-		BuildingType=BUILDING_ORTHODOX_TEMPLE
-		BuildingType=BUILDING_ORTHODOX_SHRINE
-		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_JEWISH_TEMPLE
 		BuildingType=BUILDING_JEWISH_SHRINE
+		BuildingType=BUILDING_ORTHODOX_TEMPLE
+		BuildingType=BUILDING_ORTHODOX_SHRINE
+		BuildingType=BUILDING_CATHOLIC_TEMPLE
+		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_DOME_OF_THE_ROCK
+		ReligionType=RELIGION_JUDAISM
+		HolyCityReligionType=RELIGION_JUDAISM
+		ReligionType=RELIGION_ORTHODOXY
+		HolyCityReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_CATHOLICISM
 		ReligionType=RELIGION_ISLAM
-		HolyCityReligionType=RELIGION_JUDAISM
-		HolyCityReligionType=RELIGION_ORTHODOXY
 		Player35Culture=200
 	EndCity
 	TeamReveal=8,35,44,
@@ -33832,8 +33878,56 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=26, (Russia)
+	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Moskva
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -33858,8 +33952,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=73,y=55
-	RouteType=ROUTE_ROAD
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=16,26,
@@ -33887,14 +33981,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Vologda
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -34122,28 +34212,16 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Muqdisho
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -34268,14 +34346,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Sam
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -34360,21 +34434,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Rostov-na-Donu
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -34722,14 +34788,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Mekke
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -34830,14 +34892,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Trabzon
 		CityPopulation=5
 		BuildingType=BUILDING_BARRACKS
@@ -35197,14 +35255,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Sana'a
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -35328,13 +35382,13 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_MINE
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	TeamReveal=8,35,44,45,
+	TeamReveal=8,26,35,44,45,
 EndPlot
 BeginPlot
 	x=76,y=46
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=8,35,44,45,
+	TeamReveal=8,26,35,44,45,
 EndPlot
 BeginPlot
 	x=76,y=47
@@ -35632,7 +35686,7 @@ BeginPlot
 	x=77,y=27
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,35,38,44,
+	TeamReveal=22,24,29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=77,y=28
@@ -35729,14 +35783,10 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Baghdad
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -35895,14 +35945,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Vyatka
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -36122,7 +36168,7 @@ BeginPlot
 	x=78,y=27
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,35,38,44,
+	TeamReveal=22,24,29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=78,y=28
@@ -36237,14 +36283,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
 	EndUnit
 	BeginCity
-		CityOwner=8
+		CityOwner=8, (Iran)
 		CityName=Tabriz
 		CityPopulation=7
 		BuildingType=BUILDING_BARRACKS
@@ -36329,14 +36371,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Samara
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -36591,7 +36629,7 @@ BeginPlot
 	x=79,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,35,38,
+	TeamReveal=22,24,35,38,45,
 EndPlot
 BeginPlot
 	x=79,y=28
@@ -36621,13 +36659,13 @@ BeginPlot
 	x=79,y=32
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,35,38,44,
+	TeamReveal=22,24,29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=79,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=35,44,
+	TeamReveal=35,44,45,
 EndPlot
 BeginPlot
 	x=79,y=34
@@ -37002,43 +37040,43 @@ BeginPlot
 	x=80,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=35,
+	TeamReveal=35,45,
 EndPlot
 BeginPlot
 	x=80,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,29,35,
+	TeamReveal=22,29,35,45,
 EndPlot
 BeginPlot
 	x=80,y=29
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=22,29,35,38,
+	TeamReveal=22,29,35,38,45,
 EndPlot
 BeginPlot
 	x=80,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,35,38,44,
+	TeamReveal=22,24,29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=80,y=31
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,35,38,44,
+	TeamReveal=22,24,29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=80,y=32
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,35,38,44,
+	TeamReveal=22,24,29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=80,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=29,35,38,44,
+	TeamReveal=29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=80,y=34
@@ -37105,19 +37143,19 @@ BeginPlot
 	x=80,y=43
 	TerrainType=TERRAIN_PLAINS
 	PlotType=0
-	TeamReveal=8,34,44,45,
+	TeamReveal=8,34,35,44,45,
 EndPlot
 BeginPlot
 	x=80,y=44
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=8,44,45,
+	TeamReveal=8,35,44,45,
 EndPlot
 BeginPlot
 	x=80,y=45
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,44,45,
+	TeamReveal=8,35,44,45,
 EndPlot
 BeginPlot
 	x=80,y=46
@@ -37253,14 +37291,10 @@ BeginPlot
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Obdorsk
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -37546,8 +37580,50 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=8, (Iran)
+	EndUnit
 	BeginCity
-		CityOwner=8
+		CityOwner=8, (Iran)
 		CityName=Isfahan
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -37566,7 +37642,7 @@ BeginPlot
 		ReligionType=RELIGION_ISLAM
 		Player8Culture=250
 	EndCity
-	TeamReveal=8,34,44,45,
+	TeamReveal=8,34,35,44,45,
 EndPlot
 BeginPlot
 	x=81,y=42
@@ -37669,14 +37745,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Ekaterinburg
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -37938,7 +38010,7 @@ BeginPlot
 	x=82,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=22,24,29,34,38,44,
 EndPlot
 BeginPlot
 	x=82,y=34
@@ -37946,28 +38018,16 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Masqat
 		CityPopulation=4
 		BuildingType=BUILDING_BARRACKS
@@ -38008,14 +38068,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
 	EndUnit
 	BeginCity
-		CityOwner=8
+		CityOwner=8, (Iran)
 		CityName=Shiraz
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -38067,7 +38123,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	TeamReveal=8,34,44,45,
+	TeamReveal=8,34,35,44,45,
 EndPlot
 BeginPlot
 	x=82,y=43
@@ -38494,28 +38550,16 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_CUIRASSIER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Merv
 		CityPopulation=4
 		BuildingType=BUILDING_STABLE
@@ -38569,6 +38613,7 @@ BeginPlot
 	x=83,y=51
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	TeamReveal=26,
 EndPlot
 BeginPlot
 	x=83,y=52
@@ -38857,31 +38902,31 @@ BeginPlot
 	x=84,y=32
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,38,44,
+	TeamReveal=5,24,29,38,44,
 EndPlot
 BeginPlot
 	x=84,y=33
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,
+	TeamReveal=5,22,24,29,34,38,44,
 EndPlot
 BeginPlot
 	x=84,y=34
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=8,22,24,29,34,38,44,
+	TeamReveal=5,8,22,24,29,34,38,44,
 EndPlot
 BeginPlot
 	x=84,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=8,22,24,29,34,38,44,45,
+	TeamReveal=5,8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=84,y=36
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,22,24,29,34,38,44,45,
+	TeamReveal=5,8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=84,y=37
@@ -38891,8 +38936,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=84,y=38
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_SPICES
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	TeamReveal=8,24,34,44,45,
@@ -38915,14 +38960,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
 	EndUnit
 	BeginCity
-		CityOwner=8
+		CityOwner=8, (Iran)
 		CityName=Herat
 		CityPopulation=5
 		BuildingType=BUILDING_BARRACKS
@@ -39067,14 +39108,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Tyumen
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -39316,61 +39353,54 @@ BeginPlot
 	x=85,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,44,
+	TeamReveal=5,29,44,
 EndPlot
 BeginPlot
 	x=85,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,44,
+	TeamReveal=5,29,44,
 EndPlot
 BeginPlot
 	x=85,y=32
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,44,
+	TeamReveal=5,24,29,44,
 EndPlot
 BeginPlot
 	x=85,y=33
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,34,44,
+	TeamReveal=5,24,29,34,44,
 EndPlot
 BeginPlot
 	x=85,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=8,24,29,34,38,44,
+	TeamReveal=5,8,24,29,34,38,44,
 EndPlot
 BeginPlot
 	x=85,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=8,22,24,29,34,38,44,45,
+	TeamReveal=5,8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=85,y=36
 	RiverNSDirection=2
 	isWOfRiver
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
 	EndUnit
 	BeginCity
-		CityOwner=34
+		CityOwner=34, (Mughals)
 		CityName=Kolachi
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -39383,7 +39413,7 @@ BeginPlot
 		ReligionType=RELIGION_ISLAM
 		Player34Culture=50
 	EndCity
-	TeamReveal=8,22,24,29,34,38,44,45,
+	TeamReveal=5,8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=85,y=37
@@ -39466,28 +39496,16 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_CUIRASSIER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Samarkand
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -39785,58 +39803,58 @@ BeginPlot
 	x=86,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=10,29,
 EndPlot
 BeginPlot
 	x=86,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=5,10,29,
 EndPlot
 BeginPlot
 	x=86,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,44,
+	TeamReveal=5,10,29,44,
 EndPlot
 BeginPlot
 	x=86,y=32
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,44,45,
+	TeamReveal=5,10,24,29,44,45,
 EndPlot
 BeginPlot
 	x=86,y=33
 	BonusType=BONUS_OIL
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,10,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=86,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=86,y=35
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=8,22,24,29,34,38,44,45,
+	TeamReveal=5,8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=86,y=36
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=8,22,24,34,38,44,45,
+	TeamReveal=5,8,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=86,y=37
-	RouteType=ROUTE_ROAD
 	ImprovementType=IMPROVEMENT_HAMLET
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	TeamReveal=8,22,24,34,38,44,45,
@@ -39857,8 +39875,8 @@ BeginPlot
 	x=86,y=39
 	RiverNSDirection=2
 	isWOfRiver
-	ImprovementType=IMPROVEMENT_QUARRY
 	BonusType=BONUS_MARBLE
+	ImprovementType=IMPROVEMENT_QUARRY
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=8,24,34,44,45,
@@ -40192,74 +40210,75 @@ BeginPlot
 	x=87,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
+	TeamReveal=10,
 EndPlot
 BeginPlot
 	x=87,y=28
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,44,
+	TeamReveal=10,29,44,
 EndPlot
 BeginPlot
 	x=87,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,44,
+	TeamReveal=10,29,44,
 EndPlot
 BeginPlot
 	x=87,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,34,44,45,
+	TeamReveal=5,10,29,34,44,45,
 EndPlot
 BeginPlot
 	x=87,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,34,44,45,
+	TeamReveal=5,10,29,34,44,45,
 EndPlot
 BeginPlot
 	x=87,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=24,29,34,44,45,
+	TeamReveal=5,10,24,29,34,44,45,
 EndPlot
 BeginPlot
 	x=87,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=36
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_COTTON
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=8,22,24,34,38,44,45,
+	TeamReveal=5,8,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=37
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,22,24,34,38,44,45,
+	TeamReveal=5,8,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=38
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=87,y=39
@@ -40276,14 +40295,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
 	EndUnit
 	BeginCity
-		CityOwner=34
+		CityOwner=34, (Mughals)
 		CityName=Lahore
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -40629,55 +40644,104 @@ BeginPlot
 	x=88,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=44,
+	TeamReveal=10,44,
 EndPlot
 BeginPlot
 	x=88,y=28
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,38,44,
+	TeamReveal=10,29,38,44,
 EndPlot
 BeginPlot
 	x=88,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,38,44,
+	TeamReveal=10,29,38,44,
 EndPlot
 BeginPlot
 	x=88,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=31
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_FISH
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=33
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_BANANA
+	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=34
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
+	EndUnit
 	BeginCity
-		CityOwner=5
+		CityOwner=5, (India)
 		CityName=Mumbai
 		CityPopulation=6
 		BuildingType=BUILDING_PALACE
@@ -40685,16 +40749,17 @@ BeginPlot
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_HARBOR
+		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_THEATRE
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_HINDU_TEMPLE
 		BuildingType=BUILDING_HINDU_MONASTERY
 		ReligionType=RELIGION_HINDUISM
+		FreeSpecialistType=SPECIALIST_GREAT_GENERAL
 		Player5Culture=75
 	EndCity
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=35
@@ -40703,7 +40768,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=36
@@ -40711,22 +40776,22 @@ BeginPlot
 	RiverWEDirection=3
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=22,24,34,38,44,45,
+	TeamReveal=5,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=37
-	RouteType=ROUTE_ROAD
-	ImprovementType=IMPROVEMENT_PASTURE
 	BonusType=BONUS_HORSE
+	ImprovementType=IMPROVEMENT_PASTURE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=22,24,34,38,44,45,
+	TeamReveal=5,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=38
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=88,y=39
@@ -40734,7 +40799,7 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=88,y=40
@@ -40744,16 +40809,16 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=88,y=41
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_SUGAR
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=8,34,44,45,
 EndPlot
 BeginPlot
 	x=88,y=42
-	ImprovementType=IMPROVEMENT_FARM
 	BonusType=BONUS_WHEAT
+	ImprovementType=IMPROVEMENT_FARM
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=8,34,44,45,
@@ -41074,65 +41139,65 @@ BeginPlot
 	x=89,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=38,44,
+	TeamReveal=10,38,44,
 EndPlot
 BeginPlot
 	x=89,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,29,38,44,
+	TeamReveal=10,22,29,38,44,
 EndPlot
 BeginPlot
 	x=89,y=29
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_PEARL
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=89,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=31
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=32
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=33
-	RouteType=ROUTE_ROAD
-	ImprovementType=IMPROVEMENT_MINE
 	BonusType=BONUS_GEMS
+	ImprovementType=IMPROVEMENT_MINE
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=34
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=35
-	RouteType=ROUTE_ROAD
 	isNOfRiver
 	RiverWEDirection=3
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=36
@@ -41143,31 +41208,31 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=37
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=89,y=38
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=89,y=39
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=89,y=40
-	ImprovementType=IMPROVEMENT_PASTURE
 	BonusType=BONUS_COW
+	ImprovementType=IMPROVEMENT_PASTURE
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=8,34,44,
@@ -41192,6 +41257,7 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	TeamReveal=34,44,
 EndPlot
 BeginPlot
 	x=89,y=44
@@ -41219,21 +41285,13 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Kashgar
 		CityPopulation=4
 		BuildingType=BUILDING_WALLS
@@ -41329,14 +41387,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Tomsk
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -41551,119 +41605,142 @@ BeginPlot
 	x=90,y=27
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=38,44,
+	TeamReveal=10,38,44,
 EndPlot
 BeginPlot
 	x=90,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=90,y=29
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=90,y=30
 	RiverNSDirection=2
 	isWOfRiver
-	ImprovementType=IMPROVEMENT_MINE
 	BonusType=BONUS_GOLD
+	ImprovementType=IMPROVEMENT_MINE
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=31
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=10, (Tamils)
+	EndUnit
 	BeginCity
-		CityOwner=10
+		CityOwner=10, (Tamils)
 		CityName=Mahishuru
 		CityPopulation=5
 		BuildingType=BUILDING_PALACE
-		BuildingType=BUILDING_BARRACKS
-		BuildingType=BUILDING_TAMIL_SANGAM
 		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_FORGE
+		BuildingType=BUILDING_TAMIL_SANGAM
 		BuildingType=BUILDING_HINDU_TEMPLE
 		BuildingType=BUILDING_HINDU_MONASTERY
-		ReligionType=RELIGION_HINDUISM
 		ReligionType=RELIGION_ISLAM
+		ReligionType=RELIGION_HINDUISM
 		Player10Culture=50
 	EndCity
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=32
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=33
 	isNOfRiver
 	RiverWEDirection=1
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_SUGAR
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,10,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=34
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,10,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=35
-	ImprovementType=IMPROVEMENT_FARM
 	BonusType=BONUS_RICE
+	ImprovementType=IMPROVEMENT_FARM
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=36
-	RouteType=ROUTE_ROAD
 	BonusType=BONUS_COTTON
 	ImprovementType=IMPROVEMENT_PLANTATION
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=37
 	isNOfRiver
 	RiverWEDirection=3
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
 	EndUnit
 	BeginCity
-		CityOwner=5
+		CityOwner=5, (India)
 		CityName=Bhopal
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -41674,32 +41751,59 @@ BeginPlot
 		ReligionType=RELIGION_HINDUISM
 		Player5Culture=75
 	EndCity
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=90,y=38
-	RouteType=ROUTE_ROAD
 	BonusType=BONUS_WHEAT
 	ImprovementType=IMPROVEMENT_FARM
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=90,y=39
-	ImprovementType=IMPROVEMENT_CAMP
 	BonusType=BONUS_IVORY
+	ImprovementType=IMPROVEMENT_CAMP
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=90,y=40
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUGHAL_SIEGE_ELEPHANT, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUGHAL_SIEGE_ELEPHANT, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_PIKEMAN, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_PIKEMAN, UnitOwner=34, (Mughals)
+	EndUnit
 	BeginCity
-		CityOwner=34
+		CityOwner=34, (Mughals)
 		CityName=Delhi
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -41713,13 +41817,13 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_CATHEDRAL
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
-		BuildingType=BUILDING_TAJ_MAHAL
 		BuildingType=BUILDING_RED_FORT
+		BuildingType=BUILDING_TAJ_MAHAL
 		ReligionType=RELIGION_ISLAM
 		ReligionType=RELIGION_HINDUISM
 		Player34Culture=250
 	EndCity
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=90,y=41
@@ -42050,22 +42154,22 @@ BeginPlot
 	x=91,y=27
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=29,38,44,
+	TeamReveal=10,29,38,44,
 EndPlot
 BeginPlot
 	x=91,y=28
-	ImprovementType=IMPROVEMENT_PASTURE
 	BonusType=BONUS_COW
+	ImprovementType=IMPROVEMENT_PASTURE
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=91,y=29
 	BonusType=BONUS_ALUMINUM
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=91,y=30
@@ -42074,63 +42178,52 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=31
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=32
-	RouteType=ROUTE_ROAD
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=33
 	isNOfRiver
 	RiverWEDirection=1
-	ImprovementType=IMPROVEMENT_CAMP
 	BonusType=BONUS_IVORY
+	ImprovementType=IMPROVEMENT_CAMP
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=34
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Hyderabad
 		CityPopulation=7
 		BuildingType=BUILDING_WALLS
@@ -42145,7 +42238,7 @@ BeginPlot
 		ReligionType=RELIGION_HINDUISM
 		Player45Culture=200
 	EndCity
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,10,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=35
@@ -42157,7 +42250,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=36
@@ -42165,7 +42258,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=37
@@ -42175,14 +42268,14 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_MINE
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=91,y=38
 	FeatureType=FEATURE_JUNGLE, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=91,y=39
@@ -42191,18 +42284,18 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=91,y=40
 	RiverNSDirection=2
 	isWOfRiver
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_DYE
+	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=91,y=41
@@ -42235,8 +42328,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=91,y=45
-	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_VILLAGE
+	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	TeamReveal=1,44,
@@ -42536,85 +42629,62 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=92,y=27
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_PEARL
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=92,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=92,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=92,y=30
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=31
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=32
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Madras
 		CityPopulation=5
 		BuildingType=BUILDING_WALLS
@@ -42629,7 +42699,7 @@ BeginPlot
 		ReligionType=RELIGION_HINDUISM
 		Player24Culture=50
 	EndCity
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=33
@@ -42638,7 +42708,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=34
@@ -42647,7 +42717,7 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=35
@@ -42657,14 +42727,14 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=36
 	FeatureType=FEATURE_JUNGLE, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=37
@@ -42673,7 +42743,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=38
@@ -42683,14 +42753,14 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=39
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=40
@@ -42700,14 +42770,14 @@ BeginPlot
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=41
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,24,34,44,45,
+	TeamReveal=1,5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=42
@@ -43021,27 +43091,23 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=93,y=27
-	ImprovementType=IMPROVEMENT_MINE
 	BonusType=BONUS_IRON
+	ImprovementType=IMPROVEMENT_MINE
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=93,y=28
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Colombo
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -43056,39 +43122,39 @@ BeginPlot
 		ReligionType=RELIGION_BUDDHISM
 		Player38Culture=50
 	EndCity
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=93,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=93,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=31
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=33
-	ImprovementType=IMPROVEMENT_PASTURE
 	BonusType=BONUS_COW
+	ImprovementType=IMPROVEMENT_PASTURE
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=34
@@ -43096,7 +43162,7 @@ BeginPlot
 	RiverWEDirection=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=35
@@ -43104,7 +43170,7 @@ BeginPlot
 	FeatureType=FEATURE_JUNGLE, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,10,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=36
@@ -43112,7 +43178,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=37
@@ -43121,7 +43187,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,38,45,
+	TeamReveal=5,24,34,38,45,
 EndPlot
 BeginPlot
 	x=93,y=38
@@ -43130,13 +43196,13 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=39
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=93,y=40
@@ -43146,13 +43212,13 @@ BeginPlot
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=93,y=41
 	TerrainType=TERRAIN_GRASS
 	PlotType=0
-	TeamReveal=1,24,34,44,45,
+	TeamReveal=1,5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=93,y=42
@@ -43195,8 +43261,8 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	ImprovementType=IMPROVEMENT_VILLAGE
-	RouteType=ROUTE_ROAD
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	TeamReveal=1,44,
@@ -43462,8 +43528,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=94,y=27
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_FISH
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=22,24,29,38,
@@ -43472,39 +43538,39 @@ BeginPlot
 	x=94,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=10,22,24,29,38,
 EndPlot
 BeginPlot
 	x=94,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=10,22,24,29,38,
 EndPlot
 BeginPlot
 	x=94,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=94,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=10,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=94,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=94,y=33
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_FISH
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=94,y=34
@@ -43522,8 +43588,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=94,y=36
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_TEA
+	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -43533,8 +43599,8 @@ BeginPlot
 	x=94,y=37
 	isNOfRiver
 	RiverWEDirection=1
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_COTTON
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=22,24,29,34,38,44,45,
@@ -43549,11 +43615,11 @@ EndPlot
 BeginPlot
 	x=94,y=39
 	BonusType=BONUS_DYE
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=94,y=40
@@ -43563,21 +43629,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
 	EndUnit
 	BeginCity
-		CityOwner=34
+		CityOwner=34, (Mughals)
 		CityName=Azimabad
 		CityPopulation=10
 		BuildingType=BUILDING_STABLE
@@ -43600,7 +43658,7 @@ BeginPlot
 		FreeSpecialistType=SPECIALIST_GREAT_PRIEST
 		Player34Culture=200
 	EndCity
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=94,y=41
@@ -43652,21 +43710,13 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_CUIRASSIER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Turfan
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -43956,13 +44006,13 @@ BeginPlot
 	x=95,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,38,44,
+	TeamReveal=24,38,44,45,
 EndPlot
 BeginPlot
 	x=95,y=32
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,38,44,
+	TeamReveal=22,24,38,44,45,
 EndPlot
 BeginPlot
 	x=95,y=33
@@ -43980,90 +44030,51 @@ BeginPlot
 	x=95,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=95,y=36
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=95,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Calcutta
 		CityPopulation=6
 		BuildingType=BUILDING_WALLS
@@ -44093,8 +44104,8 @@ BeginPlot
 	x=95,y=39
 	RiverNSDirection=2
 	isWOfRiver
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_BANANA
+	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -44104,8 +44115,8 @@ BeginPlot
 	x=95,y=40
 	isNOfRiver
 	RiverWEDirection=1
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_TEA
+	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -44467,14 +44478,14 @@ BeginPlot
 	x=96,y=35
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,29,36,38,44,45,
+	TeamReveal=22,24,29,34,36,38,44,45,
 EndPlot
 BeginPlot
 	x=96,y=36
-	TerrainType=TERRAIN_COAST
 	BonusType=BONUS_FISH
+	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=96,y=37
@@ -44535,14 +44546,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (China)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (China)
 		CityName=Lasa
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -44577,8 +44584,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=96,y=47
-	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_VILLAGE
+	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	TeamReveal=1,44,
@@ -44897,13 +44904,13 @@ BeginPlot
 	x=97,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=1,22,24,29,36,38,44,45,
+	TeamReveal=1,22,24,29,34,36,38,44,45,
 EndPlot
 BeginPlot
 	x=97,y=36
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=1,22,24,29,38,44,45,
+	TeamReveal=1,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=97,y=37
@@ -45306,28 +45313,16 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Yangon
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -45343,7 +45338,7 @@ BeginPlot
 		ReligionType=RELIGION_BUDDHISM
 		Player44Culture=100
 	EndCity
-	TeamReveal=1,22,24,29,36,38,44,45,
+	TeamReveal=1,22,24,29,34,36,38,44,45,
 EndPlot
 BeginPlot
 	x=98,y=37
@@ -45372,14 +45367,14 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=1,34,44,45,
+	TeamReveal=1,24,34,44,45,
 EndPlot
 BeginPlot
 	x=98,y=40
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,34,44,45,
+	TeamReveal=1,24,34,44,45,
 EndPlot
 BeginPlot
 	x=98,y=41
@@ -45714,8 +45709,8 @@ EndPlot
 BeginPlot
 	x=99,y=28
 	BonusType=BONUS_SUGAR
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -45768,8 +45763,8 @@ EndPlot
 BeginPlot
 	x=99,y=36
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -45778,8 +45773,8 @@ EndPlot
 BeginPlot
 	x=99,y=37
 	BonusType=BONUS_TEA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -45801,7 +45796,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,34,44,45,
+	TeamReveal=1,24,34,44,45,
 EndPlot
 BeginPlot
 	x=99,y=40
@@ -45810,7 +45805,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,34,44,45,
+	TeamReveal=1,24,34,44,45,
 EndPlot
 BeginPlot
 	x=99,y=41
@@ -45820,14 +45815,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Chengdu
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -46155,28 +46146,16 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Palembang
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -46193,8 +46172,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=100,y=27
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_VILLAGE
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=29,38,44,45,
@@ -46214,8 +46193,8 @@ EndPlot
 BeginPlot
 	x=100,y=30
 	BonusType=BONUS_SUGAR
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -46224,8 +46203,8 @@ EndPlot
 BeginPlot
 	x=100,y=31
 	BonusType=BONUS_DYE
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -46234,8 +46213,8 @@ EndPlot
 BeginPlot
 	x=100,y=32
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -46246,8 +46225,8 @@ BeginPlot
 	RiverNSDirection=2
 	isWOfRiver
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -46343,14 +46322,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Xi'an
 		CityPopulation=8
 		BuildingType=BUILDING_BARRACKS
@@ -46683,21 +46658,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Malakka
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -46740,8 +46707,44 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_THAI_CHANG_SUEK, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_THAI_CHANG_SUEK, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_THAI_CHANG_SUEK, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_THAI_CHANG_SUEK, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_PIKEMAN, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_PIKEMAN, UnitOwner=36, (Thailand)
+	EndUnit
 	BeginCity
-		CityOwner=36
+		CityOwner=36, (Thailand)
 		CityName=Ayutthaya
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -46800,35 +46803,19 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Hanoi
 		CityPopulation=7
 		BuildingType=BUILDING_GRANARY
@@ -46849,8 +46836,8 @@ EndPlot
 BeginPlot
 	x=101,y=38
 	BonusType=BONUS_TEA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -47285,8 +47272,8 @@ EndPlot
 BeginPlot
 	x=102,y=38
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -47315,14 +47302,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Chongqing
 		CityPopulation=7
 		BuildingType=BUILDING_GRANARY
@@ -47388,12 +47371,62 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
+	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Beijing
 		CityPopulation=9
 		BuildingType=BUILDING_PALACE
-		BuildingType=BUILDING_FORBIDDEN_PALACE
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
@@ -47405,6 +47438,7 @@ BeginPlot
 		BuildingType=BUILDING_CONFUCIAN_MONASTERY
 		BuildingType=BUILDING_TAOIST_TEMPLE
 		BuildingType=BUILDING_GREAT_WALL
+		BuildingType=BUILDING_FORBIDDEN_PALACE
 		ReligionType=RELIGION_CONFUCIANISM
 		ReligionType=RELIGION_TAOISM
 		Player1Culture=150
@@ -47727,7 +47761,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,22,29,36,38,
+	TeamReveal=1,22,29,36,38,44,
 EndPlot
 BeginPlot
 	x=103,y=34
@@ -47741,8 +47775,8 @@ EndPlot
 BeginPlot
 	x=103,y=35
 	BonusType=BONUS_DYE
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=1,22,29,36,38,44,45,
@@ -47764,8 +47798,8 @@ EndPlot
 BeginPlot
 	x=103,y=38
 	BonusType=BONUS_SILK
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -47818,14 +47852,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Kaifeng
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -47923,13 +47953,14 @@ BeginPlot
 	x=103,y=54
 	TerrainType=TERRAIN_GRASS
 	PlotType=0
-	TeamReveal=1,
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=103,y=55
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=103,y=56
@@ -48146,35 +48177,19 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Batavia
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -48200,8 +48215,8 @@ EndPlot
 BeginPlot
 	x=104,y=27
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -48211,33 +48226,20 @@ BeginPlot
 	x=104,y=28
 	isNOfRiver
 	RiverWEDirection=3
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Pontianak
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -48280,31 +48282,20 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=104,y=33
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Saigon
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -48320,7 +48311,7 @@ BeginPlot
 		ReligionType=RELIGION_CONFUCIANISM
 		Player44Culture=50
 	EndCity
-	TeamReveal=1,22,29,36,38,
+	TeamReveal=1,22,29,36,38,44,
 EndPlot
 BeginPlot
 	x=104,y=34
@@ -48490,7 +48481,7 @@ BeginPlot
 	x=104,y=55
 	TerrainType=TERRAIN_GRASS
 	PlotType=0
-	TeamReveal=1,
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=104,y=56
@@ -48717,8 +48708,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=105,y=27
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_VILLAGE
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -48760,11 +48751,11 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=105,y=33
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_CLAM
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,29,36,
+	TeamReveal=22,29,36,44,
 EndPlot
 BeginPlot
 	x=105,y=34
@@ -48802,18 +48793,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Guangzhou
 		CityPopulation=10
 		BuildingType=BUILDING_GRANARY
-		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_LIGHTHOUSE
 		BuildingType=BUILDING_HARBOR
@@ -48830,8 +48816,8 @@ EndPlot
 BeginPlot
 	x=105,y=40
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=1,22,29,45,
@@ -48904,21 +48890,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Shenyang
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -48973,6 +48951,7 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=105,y=56
@@ -49182,8 +49161,8 @@ EndPlot
 BeginPlot
 	x=106,y=25
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -49267,7 +49246,7 @@ BeginPlot
 	x=106,y=37
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=1,22,29,45,
+	TeamReveal=1,22,29,44,45,
 EndPlot
 BeginPlot
 	x=106,y=38
@@ -49325,14 +49304,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Shanghai
 		CityPopulation=10
 		BuildingType=BUILDING_GRANARY
@@ -49398,8 +49373,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=106,y=51
-	RouteType=ROUTE_ROAD
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=1,12,44,45,
@@ -49425,19 +49400,21 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=1,
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=106,y=55
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=106,y=56
 	FeatureType=FEATURE_FOREST, FeatureVariety=2
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=106,y=57
@@ -49634,8 +49611,8 @@ EndPlot
 BeginPlot
 	x=107,y=24
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -49717,7 +49694,7 @@ BeginPlot
 	x=107,y=37
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=1,15,22,29,45,
+	TeamReveal=1,15,22,29,44,45,
 EndPlot
 BeginPlot
 	x=107,y=38
@@ -49752,14 +49729,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Hangzhou
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -49844,26 +49817,23 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=107,y=52
-	RouteType=ROUTE_ROAD
 	BonusType=BONUS_OIL
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=1,12,44,
 EndPlot
 BeginPlot
 	x=107,y=53
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (China)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (China)
 		CityName=Qiqihar
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -49882,7 +49852,7 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=1,
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=107,y=55
@@ -49890,6 +49860,7 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=107,y=56
@@ -49897,6 +49868,7 @@ BeginPlot
 	isWOfRiver
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=0
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=107,y=57
@@ -50106,33 +50078,20 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=108,y=26
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Makassar
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -50195,8 +50154,8 @@ EndPlot
 BeginPlot
 	x=108,y=34
 	BonusType=BONUS_SUGAR
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -50296,21 +50255,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=12
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=12
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
 	EndUnit
 	BeginCity
-		CityOwner=12
+		CityOwner=12, (Korea)
 		CityName=Pyongyang
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -50376,18 +50327,20 @@ BeginPlot
 	FeatureType=FEATURE_MARSH, FeatureVariety=0
 	TerrainType=TERRAIN_MARSH
 	PlotType=2
-	TeamReveal=1,
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=108,y=55
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=108,y=56
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=0
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=108,y=57
@@ -50599,8 +50552,8 @@ EndPlot
 BeginPlot
 	x=109,y=26
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -50652,23 +50605,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Manila
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -50686,8 +50629,8 @@ EndPlot
 BeginPlot
 	x=109,y=34
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -50768,8 +50711,38 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=12, (Korea)
+	EndUnit
 	BeginCity
-		CityOwner=12
+		CityOwner=12, (Korea)
 		CityName=Hanseong
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -50852,19 +50825,21 @@ BeginPlot
 	FeatureType=FEATURE_MARSH, FeatureVariety=0
 	TerrainType=TERRAIN_MARSH
 	PlotType=2
-	TeamReveal=1,
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=109,y=55
 	FeatureType=FEATURE_FOREST, FeatureVariety=2
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=109,y=56
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=1
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=109,y=57
@@ -51107,8 +51082,8 @@ EndPlot
 BeginPlot
 	x=110,y=31
 	BonusType=BONUS_SILK
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -51262,7 +51237,7 @@ BeginPlot
 	FeatureType=FEATURE_MARSH, FeatureVariety=0
 	TerrainType=TERRAIN_MARSH
 	PlotType=2
-	TeamReveal=1,15,
+	TeamReveal=1,15,44,
 EndPlot
 BeginPlot
 	x=110,y=54
@@ -51271,7 +51246,7 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=1
-	TeamReveal=1,15,
+	TeamReveal=1,15,44,
 EndPlot
 BeginPlot
 	x=110,y=55
@@ -51489,8 +51464,8 @@ EndPlot
 BeginPlot
 	x=111,y=26
 	BonusType=BONUS_DYE
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -51499,19 +51474,14 @@ EndPlot
 BeginPlot
 	x=111,y=27
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Ambon
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -52003,14 +51973,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
 	EndUnit
 	BeginCity
-		CityOwner=15
+		CityOwner=15, (Japan)
 		CityName=Kagoshima
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -52341,8 +52307,8 @@ EndPlot
 BeginPlot
 	x=113,y=27
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=38,
@@ -52455,8 +52421,53 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=15, (Japan)
+	EndUnit
+(	BeginUnit)
+(		UnitType=UNIT_SETTLER, UnitOwner=15, (Japan)) (AI only)
+(	EndUnit)
 	BeginCity
-		CityOwner=15
+		CityOwner=15, (Japan)
 		CityName=Kyouto
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -53696,14 +53707,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
 	EndUnit
 	BeginCity
-		CityOwner=15
+		CityOwner=15, (Japan)
 		CityName=Edo
 		CityPopulation=12
 		BuildingType=BUILDING_GRANARY
@@ -56360,5 +56367,3 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 EndPlot
-
-### Sign Info ###

--- a/PrivateMaps/RFC 1700 AD.CivBeyondSwordWBSave
+++ b/PrivateMaps/RFC 1700 AD.CivBeyondSwordWBSave
@@ -6405,14 +6405,10 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Hermosillo
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -6801,14 +6797,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Guadalajara
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -7587,14 +7579,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Ciudad de M&#233;xico
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -7631,14 +7619,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Monterrey
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -8055,8 +8039,8 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
@@ -9202,9 +9186,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=22,y=33
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=22,24,44,
@@ -9276,28 +9260,16 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Nouvelle Orl&#233;ans
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -9665,14 +9637,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Ciudad de Guatemala
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -9702,8 +9670,8 @@ EndPlot
 BeginPlot
 	x=23,y=36
 	BonusType=BONUS_DYE
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -9715,14 +9683,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Ciudad Real
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -10092,14 +10056,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Quito
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -10604,8 +10564,8 @@ EndPlot
 BeginPlot
 	x=25,y=38
 	BonusType=BONUS_TOBACCO
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=22,23,24,44,45,
@@ -10642,14 +10602,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Charles Town
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -10942,14 +10898,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Lima
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -10993,9 +10945,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=26,y=27
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_COFFEE
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -11077,23 +11029,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=La Habana
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -11442,8 +11384,8 @@ EndPlot
 BeginPlot
 	x=27,y=24
 	BonusType=BONUS_SILVER
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_MINE
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -11487,14 +11429,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Bogot&#225;
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -11508,18 +11446,18 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=27,y=30
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_COFFEE
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=22,45,
 EndPlot
 BeginPlot
 	x=27,y=31
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=22,24,45,
@@ -11658,28 +11596,16 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=York
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -12279,14 +12205,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Santiago de Chile
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -12436,9 +12358,9 @@ BeginPlot
 	x=29,y=30
 	isNOfRiver
 	RiverWEDirection=1
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_COFFEE
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -12489,14 +12411,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Port-au-Prince
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -12932,14 +12850,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Caracas
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -13058,21 +12972,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=New York
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -13119,28 +13025,16 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Montr&#233;al
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -13367,14 +13261,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=La Paz
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -13601,14 +13491,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Boston
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -13973,19 +13859,14 @@ EndPlot
 BeginPlot
 	x=32,y=37
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=San Juan
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -14317,8 +14198,8 @@ EndPlot
 BeginPlot
 	x=33,y=20
 	BonusType=BONUS_SILVER
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_MINE
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -14429,14 +14310,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Bridgetown
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -14720,23 +14597,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Buenos Aires
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -14898,14 +14765,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Georgetown
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -15659,14 +15522,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Montevideo
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -15788,8 +15647,8 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -15957,14 +15816,10 @@ BeginPlot
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=St. John's
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -16252,14 +16107,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Cayenne
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -16599,14 +16450,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=S&#227;o Paulo
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -16678,8 +16525,8 @@ EndPlot
 BeginPlot
 	x=38,y=25
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=23,29,44,
@@ -16690,14 +16537,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Bel&#233;m
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -17118,9 +16961,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=39,y=26
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
@@ -17880,37 +17723,25 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Rio de Janeiro
 		CityPopulation=5
-		BuildingType=BUILDING_ADMINISTRATIVE_CENTER
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_LIGHTHOUSE
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_COURTHOUSE
+		BuildingType=BUILDING_ADMINISTRATIVE_CENTER
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
 		Player29Culture=100
@@ -18362,14 +18193,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Recife
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -18768,9 +18595,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=43,y=23
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
@@ -19217,25 +19044,25 @@ BeginPlot
 	x=44,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=44,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=44,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=44,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=44,y=34
@@ -19297,14 +19124,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Ponta Delgada
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -19629,43 +19452,43 @@ BeginPlot
 	x=45,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=23,29,
 EndPlot
 BeginPlot
 	x=45,y=36
@@ -19833,14 +19656,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Reykjavik
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -20045,44 +19864,44 @@ BeginPlot
 	x=46,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,38,
+	TeamReveal=23,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=35
 	FeatureType=FEATURE_ISLANDS, FeatureVariety=0
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,29,
+	TeamReveal=22,23,29,
 EndPlot
 BeginPlot
 	x=46,y=36
@@ -20434,43 +20253,43 @@ BeginPlot
 	x=47,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,45,
+	TeamReveal=22,23,24,29,38,45,
 EndPlot
 BeginPlot
 	x=47,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,45,
+	TeamReveal=22,23,24,29,38,45,
 EndPlot
 BeginPlot
 	x=47,y=31
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=47,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=47,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=47,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=22,23,24,29,38,44,
 EndPlot
 BeginPlot
 	x=47,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=22,23,24,29,38,44,
 EndPlot
 BeginPlot
 	x=47,y=36
@@ -20493,14 +20312,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Funchal
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -20844,20 +20659,20 @@ BeginPlot
 	x=48,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,45,
+	TeamReveal=22,23,24,29,38,45,
 EndPlot
 BeginPlot
 	x=48,y=30
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,38,45,
+	TeamReveal=22,23,24,29,38,45,
 EndPlot
 BeginPlot
 	x=48,y=31
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,38,45,
+	TeamReveal=22,23,24,29,38,45,
 EndPlot
 BeginPlot
 	x=48,y=32
@@ -20867,14 +20682,10 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Saint-Louis du S&#233;n&#233;gal
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -20885,26 +20696,26 @@ BeginPlot
 		ReligionType=RELIGION_CATHOLICISM
 		Player23Culture=50
 	EndCity
-	TeamReveal=22,24,29,38,
+	TeamReveal=22,23,24,29,38,
 EndPlot
 BeginPlot
 	x=48,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=22,23,24,29,38,44,
 EndPlot
 BeginPlot
 	x=48,y=34
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=22,23,24,29,38,44,
 EndPlot
 BeginPlot
 	x=48,y=35
 	FeatureType=FEATURE_CAPE, FeatureVariety=0
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=22,23,24,29,38,44,
 EndPlot
 BeginPlot
 	x=48,y=36
@@ -20972,6 +20783,7 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,22,23,24,29,38,45,
+	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=48,y=46
@@ -21344,6 +21156,7 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,22,23,24,29,38,44,45,
+	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=49,y=41
@@ -21367,8 +21180,41 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=29, (Portugal)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=29, (Portugal)
+	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Lisboa
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -21417,14 +21263,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=La Coru&#241;a
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -21501,14 +21343,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Dublin
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -21749,7 +21587,7 @@ BeginPlot
 	x=50,y=29
 	TerrainType=TERRAIN_PLAINS
 	PlotType=0
-	TeamReveal=22,24,38,44,45,
+	TeamReveal=22,23,24,38,44,45,
 EndPlot
 BeginPlot
 	x=50,y=30
@@ -21791,7 +21629,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	TeamReveal=22,29,44,45,
+	TeamReveal=22,23,29,44,45,
 EndPlot
 BeginPlot
 	x=50,y=36
@@ -21841,6 +21679,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,22,23,24,29,38,45,
+	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=50,y=43
@@ -21852,6 +21691,7 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=16,22,23,24,29,38,45,
+	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=50,y=44
@@ -21860,6 +21700,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,29,38,45,
+	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=50,y=45
@@ -22169,21 +22010,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Djenne
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -22205,19 +22038,19 @@ BeginPlot
 	x=51,y=31
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=45,
+	TeamReveal=23,45,
 EndPlot
 BeginPlot
 	x=51,y=32
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=45,
+	TeamReveal=23,45,
 EndPlot
 BeginPlot
 	x=51,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=44,45,
+	TeamReveal=23,44,45,
 EndPlot
 BeginPlot
 	x=51,y=34
@@ -22229,7 +22062,7 @@ BeginPlot
 	x=51,y=35
 	TerrainType=TERRAIN_DESERT
 	PlotType=0
-	TeamReveal=29,44,45,
+	TeamReveal=23,29,44,45,
 EndPlot
 BeginPlot
 	x=51,y=36
@@ -22244,21 +22077,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Marrakus
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -22301,50 +22126,22 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Sevilla
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -22825,8 +22622,44 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_SPANISH_CONQUISTADOR, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SPANISH_CONQUISTADOR, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SPANISH_CONQUISTADOR, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SPANISH_CONQUISTADOR, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=22, (Spain)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=22, (Spain)
+	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Madrid
 		CityPopulation=8
 		BuildingType=BUILDING_PALACE
@@ -22965,14 +22798,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Edinburgh
 		CityPopulation=7
 		BuildingType=BUILDING_BARRACKS
@@ -23194,8 +23023,8 @@ EndPlot
 BeginPlot
 	x=53,y=28
 	BonusType=BONUS_GOLD
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_MINE
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -23223,28 +23052,16 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Timbuktu
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -23380,42 +23197,22 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Bordeaux
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -23479,8 +23276,56 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=London
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -23492,7 +23337,6 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CUSTOMS_HOUSE
 		BuildingType=BUILDING_FORGE
-		BuildingType=BUILDING_ACADEMY
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_UNIVERSITY
 		BuildingType=BUILDING_THEATRE
@@ -23500,6 +23344,7 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_ENGLISH_ROYAL_EXCHANGE
 		BuildingType=BUILDING_COURTHOUSE
+		BuildingType=BUILDING_ACADEMY
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		BuildingType=BUILDING_PROTESTANT_CATHEDRAL
 		BuildingType=BUILDING_TRADING_COMPANY
@@ -23737,14 +23582,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Elmina
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -23752,8 +23593,8 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
-		ReligionType=RELIGION_PROTESTANTISM
 		ReligionType=RELIGION_CATHOLICISM
+		ReligionType=RELIGION_PROTESTANTISM
 		Player38Culture=50
 	EndCity
 	TeamReveal=22,24,29,38,45,
@@ -23857,14 +23698,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Wahran
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -24349,14 +24186,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Barcelona
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -24423,8 +24256,71 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=23, (France)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=23, (France)
+	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Paris
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -24433,7 +24329,6 @@ BeginPlot
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_AQUEDUCT
 		BuildingType=BUILDING_FORGE
-		BuildingType=BUILDING_ACADEMY
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_UNIVERSITY
 		BuildingType=BUILDING_AMPHITHEATRE
@@ -24442,6 +24337,7 @@ BeginPlot
 		BuildingType=BUILDING_BANK
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_FRENCH_SALON
+		BuildingType=BUILDING_ACADEMY
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_CATHEDRAL
 		BuildingType=BUILDING_TRADING_COMPANY
@@ -24730,21 +24626,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Gao
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -24870,14 +24758,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
 	EndUnit
 	BeginCity
-		CityOwner=23
+		CityOwner=23, (France)
 		CityName=Marseille
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -25379,8 +25263,38 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=38, (Netherlands)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=38, (Netherlands)
+	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Amsterdam
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -25400,12 +25314,12 @@ BeginPlot
 		BuildingType=BUILDING_BANK
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_DUTCH_DIKE
-		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
+		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		BuildingType=BUILDING_TRADING_COMPANY
 		ReligionType=RELIGION_JUDAISM
-		ReligionType=RELIGION_PROTESTANTISM
 		ReligionType=RELIGION_CATHOLICISM
+		ReligionType=RELIGION_PROTESTANTISM
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		Player38Culture=250
@@ -25730,14 +25644,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Tunus
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -25822,6 +25732,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,38,39,44,45,
+	Player39Culture=100, (Germany)
 EndPlot
 BeginPlot
 	x=58,y=50
@@ -25847,6 +25758,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,22,23,24,25,38,39,45,
+	Player38Culture=100, (Netherlands)
 EndPlot
 BeginPlot
 	x=58,y=53
@@ -25855,6 +25767,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,22,23,24,25,38,39,44,45,
+	Player38Culture=100, (Netherlands)
 EndPlot
 BeginPlot
 	x=58,y=54
@@ -25908,21 +25821,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Bergen
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -26135,15 +26040,11 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
-		CityName=TXT_KEY_CITY_NAME_LAGOS
+		CityOwner=29, (Portugal)
+		CityName=Lagos
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
@@ -26180,21 +26081,13 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Ngazargamu
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -26324,21 +26217,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
 	EndUnit
 	BeginCity
-		CityOwner=25
+		CityOwner=25, (Holy Rome)
 		CityName=Mailand
 		CityPopulation=7
 		BuildingType=BUILDING_BARRACKS
@@ -26377,6 +26262,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,38,39,44,45,
+	Player39Culture=100, (Germany)
 EndPlot
 BeginPlot
 	x=59,y=50
@@ -26394,21 +26280,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
 	EndUnit
 	BeginCity
-		CityOwner=39
+		CityOwner=39, (Germany)
 		CityName=Frankfurt
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -26421,15 +26299,15 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_BANK
 		BuildingType=BUILDING_COURTHOUSE
+		BuildingType=BUILDING_MILITARY_ACADEMY
+		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		BuildingType=BUILDING_PROTESTANT_CATHEDRAL
 		BuildingType=BUILDING_PROTESTANT_SHRINE
-		BuildingType=BUILDING_CATHOLIC_TEMPLE
-		BuildingType=BUILDING_MILITARY_ACADEMY
-		ReligionType=RELIGION_PROTESTANTISM
-		HolyCityReligionType=RELIGION_PROTESTANTISM
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
+		ReligionType=RELIGION_PROTESTANTISM
+		HolyCityReligionType=RELIGION_PROTESTANTISM
 		Player39Culture=100
 	EndCity
 	TeamReveal=16,22,23,24,25,38,39,45,
@@ -26462,35 +26340,19 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=39, (Germany)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=39, (Germany)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
 	EndUnit
 	BeginCity
-		CityOwner=39
+		CityOwner=39, (Germany)
 		CityName=Hamburg
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -26504,9 +26366,8 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
-		ReligionType=RELIGION_PROTESTANTISM
 		ReligionType=RELIGION_CATHOLICISM
-		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
+		ReligionType=RELIGION_PROTESTANTISM
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		Player39Culture=100
 	EndCity
@@ -26886,35 +26747,19 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Roma
 		CityPopulation=8
 		BuildingType=BUILDING_WALLS
@@ -26982,6 +26827,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,38,39,44,45,
+	Player39Culture=100, (Germany)
 EndPlot
 BeginPlot
 	x=60,y=50
@@ -27041,35 +26887,19 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_RIFLEMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=K&#248;benhavn
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -27106,28 +26936,16 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Oslo
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -27341,8 +27159,8 @@ EndPlot
 BeginPlot
 	x=61,y=22
 	BonusType=BONUS_COTTON
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -27450,14 +27268,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Trablus
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -27665,21 +27479,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Trondheim
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -27842,8 +27648,56 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CATAPULT, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CATAPULT, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=37, (Congo)
+	EndUnit
 	BeginCity
-		CityOwner=37
+		CityOwner=37, (Congo)
 		CityName=Mbanza Kongo
 		CityPopulation=8
 		BuildingType=BUILDING_PALACE
@@ -28015,14 +27869,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
 	EndUnit
 	BeginCity
-		CityOwner=25
+		CityOwner=25, (Holy Rome)
 		CityName=Neapel
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -28091,8 +27941,32 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=25, (Holy Rome)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=25, (Holy Rome)
+	EndUnit
 	BeginCity
-		CityOwner=25
+		CityOwner=25, (Holy Rome)
 		CityName=Wien
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -28108,10 +27982,10 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_BANK
 		BuildingType=BUILDING_HOLY_ROMAN_RATHAUS
+		BuildingType=BUILDING_MILITARY_ACADEMY
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_CATHEDRAL
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
-		BuildingType=BUILDING_MILITARY_ACADEMY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
 		Player25Culture=250
@@ -28134,6 +28008,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,26,28,38,39,45,
+	Player25Culture=100, (Holy Rome)
 EndPlot
 BeginPlot
 	x=62,y=52
@@ -28148,8 +28023,41 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=39, (Germany)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CANNON, UnitOwner=39, (Germany)
+	EndUnit
 	BeginCity
-		CityOwner=39
+		CityOwner=39, (Germany)
 		CityName=Berlin
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -28332,21 +28240,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Kaapstad
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -28704,8 +28604,44 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=16, (Vikings)
+	EndUnit
 	BeginCity
-		CityOwner=16
+		CityOwner=16, (Vikings)
 		CityName=Stockholm
 		CityPopulation=8
 		BuildingType=BUILDING_PALACE
@@ -28909,9 +28845,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=64,y=20
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
@@ -29157,6 +29093,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,23,25,26,28,38,39,44,45,
+	Player28Culture=100, (Poland)
 EndPlot
 BeginPlot
 	x=64,y=54
@@ -29557,21 +29494,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Belgrad
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -29615,21 +29544,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
 	EndUnit
 	BeginCity
-		CityOwner=25
+		CityOwner=25, (Holy Rome)
 		CityName=Budapest
 		CityPopulation=8
 		BuildingType=BUILDING_BARRACKS
@@ -29678,8 +29599,44 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=28, (Poland)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=28, (Poland)
+	EndUnit
 	BeginCity
-		CityOwner=28
+		CityOwner=28, (Poland)
 		CityName=Warszawa
 		CityPopulation=8
 		BuildingType=BUILDING_PALACE
@@ -29718,14 +29675,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
 	EndUnit
 	BeginCity
-		CityOwner=39
+		CityOwner=39, (Germany)
 		CityName=K&#246;nigsberg
 		CityPopulation=4
 		BuildingType=BUILDING_BARRACKS
@@ -29793,14 +29746,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
 	EndUnit
 	BeginCity
-		CityOwner=16
+		CityOwner=16, (Vikings)
 		CityName=Lule&#229;
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -30254,6 +30203,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,25,26,28,39,45,
+	Player28Culture=100, (Poland)
 EndPlot
 BeginPlot
 	x=66,y=56
@@ -30593,14 +30543,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Iskenderiye
 		CityPopulation=10
 		BuildingType=BUILDING_GRANARY
@@ -30616,8 +30562,8 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_CATHEDRAL
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
-		BuildingType=BUILDING_GREAT_LIBRARY
 		BuildingType=BUILDING_GREAT_LIGHTHOUSE
+		BuildingType=BUILDING_GREAT_LIBRARY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
@@ -30645,8 +30591,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=67,y=40
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_CLAM
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=35,44,
@@ -30657,14 +30603,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Atina
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -30785,21 +30727,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=28
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=28
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
 	EndUnit
 	BeginCity
-		CityOwner=28
+		CityOwner=28, (Poland)
 		CityName=Wilno
 		CityPopulation=5
 		BuildingType=BUILDING_BARRACKS
@@ -30833,12 +30767,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,26,28,39,
+	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=67,y=58
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,26,28,39,45,
+	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=67,y=59
@@ -30848,14 +30784,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
 	EndUnit
 	BeginCity
-		CityOwner=16
+		CityOwner=16, (Vikings)
 		CityName=Helsingfors
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -31257,8 +31189,65 @@ BeginPlot
 	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
+	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Kostantiniyye
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -31277,15 +31266,15 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_COURTHOUSE
+		BuildingType=BUILDING_MILITARY_ACADEMY
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_CATHEDRAL
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
-		BuildingType=BUILDING_MILITARY_ACADEMY
 		BuildingType=BUILDING_THEODOSIAN_WALLS
 		BuildingType=BUILDING_HAGIA_SOPHIA
-		BuildingType=BUILDING_TOPKAPI_PALACE
 		BuildingType=BUILDING_BLUE_MOSQUE
+		BuildingType=BUILDING_TOPKAPI_PALACE
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
@@ -31390,6 +31379,7 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,26,28,39,45,
+	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=68,y=59
@@ -31397,6 +31387,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,26,28,39,45,
+	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=68,y=60
@@ -31665,14 +31656,10 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=El-Uqsur
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -31711,14 +31698,10 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=El-Kahire
 		CityPopulation=7
 		BuildingType=BUILDING_BARRACKS
@@ -31731,8 +31714,8 @@ BeginPlot
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
-		BuildingType=BUILDING_PYRAMIDS
 		BuildingType=BUILDING_GREAT_SPHINX
+		BuildingType=BUILDING_PYRAMIDS
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
@@ -31862,21 +31845,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Kiev
 		CityPopulation=8
 		BuildingType=BUILDING_BARRACKS
@@ -31916,6 +31891,7 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=16,26,28,39,45,
+	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=69,y=55
@@ -31930,6 +31906,7 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,26,28,39,45,
+	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=69,y=57
@@ -31946,21 +31923,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Sankt-Peterburg
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -32444,7 +32413,7 @@ BeginPlot
 	x=70,y=58
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=16,26,39,45,
+	TeamReveal=16,26,28,39,45,
 EndPlot
 BeginPlot
 	x=70,y=59
@@ -32454,7 +32423,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=16,26,39,45,
+	TeamReveal=16,26,28,39,45,
 EndPlot
 BeginPlot
 	x=70,y=60
@@ -32598,14 +32567,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
 	EndUnit
 	BeginCity
-		CityOwner=29
+		CityOwner=29, (Portugal)
 		CityName=Mo&#231;ambique
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -32654,21 +32619,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Mombasa
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -32841,14 +32798,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Ankara
 		CityPopulation=5
 		BuildingType=BUILDING_BARRACKS
@@ -32957,7 +32910,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=16,26,
+	TeamReveal=16,26,28,
 EndPlot
 BeginPlot
 	x=71,y=57
@@ -32972,13 +32925,13 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_VILLAGE
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=16,26,
+	TeamReveal=16,26,28,
 EndPlot
 BeginPlot
 	x=71,y=59
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=16,26,
+	TeamReveal=16,26,28,
 EndPlot
 BeginPlot
 	x=71,y=60
@@ -33215,21 +33168,13 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Gondar
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -33478,14 +33423,10 @@ BeginPlot
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Arkhangelsk
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -33783,14 +33724,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Kud&#252;s
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -33800,17 +33737,19 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_MARKET
-		BuildingType=BUILDING_CATHOLIC_TEMPLE
-		BuildingType=BUILDING_ORTHODOX_TEMPLE
-		BuildingType=BUILDING_ORTHODOX_SHRINE
-		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_JEWISH_TEMPLE
 		BuildingType=BUILDING_JEWISH_SHRINE
+		BuildingType=BUILDING_ORTHODOX_TEMPLE
+		BuildingType=BUILDING_ORTHODOX_SHRINE
+		BuildingType=BUILDING_CATHOLIC_TEMPLE
+		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_DOME_OF_THE_ROCK
+		ReligionType=RELIGION_JUDAISM
+		HolyCityReligionType=RELIGION_JUDAISM
+		ReligionType=RELIGION_ORTHODOXY
+		HolyCityReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_CATHOLICISM
 		ReligionType=RELIGION_ISLAM
-		HolyCityReligionType=RELIGION_JUDAISM
-		HolyCityReligionType=RELIGION_ORTHODOXY
 		Player35Culture=200
 	EndCity
 	TeamReveal=8,35,44,
@@ -33939,8 +33878,56 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=26, (Russia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=26, (Russia)
+	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Moskva
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -33965,8 +33952,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=73,y=55
-	RouteType=ROUTE_ROAD
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=16,26,
@@ -33994,14 +33981,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Vologda
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -34229,28 +34212,16 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Muqdisho
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -34375,14 +34346,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Sam
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -34467,21 +34434,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Rostov-na-Donu
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -34829,14 +34788,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Mekke
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY

--- a/PrivateMaps/RFC 1700 AD.CivBeyondSwordWBSave
+++ b/PrivateMaps/RFC 1700 AD.CivBeyondSwordWBSave
@@ -6405,10 +6405,14 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Hermosillo
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -6797,10 +6801,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Guadalajara
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -7579,10 +7587,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Ciudad de M&#233;xico
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -7619,10 +7631,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Monterrey
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -8039,8 +8055,8 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	BonusType=BONUS_SPICES
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
@@ -9186,9 +9202,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=22,y=33
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=22,24,44,
@@ -9260,16 +9276,28 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
+		UnitType=UNIT_GALLEON, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=23, (France)
+		CityOwner=23
 		CityName=Nouvelle Orl&#233;ans
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -9637,10 +9665,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Ciudad de Guatemala
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -9670,8 +9702,8 @@ EndPlot
 BeginPlot
 	x=23,y=36
 	BonusType=BONUS_DYE
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -9683,10 +9715,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Ciudad Real
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -10056,10 +10092,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Quito
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -10564,8 +10604,8 @@ EndPlot
 BeginPlot
 	x=25,y=38
 	BonusType=BONUS_TOBACCO
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=22,23,24,44,45,
@@ -10602,10 +10642,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=24, (England)
+		CityOwner=24
 		CityName=Charles Town
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -10898,10 +10942,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Lima
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -10945,9 +10993,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=26,y=27
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_COFFEE
 	ImprovementType=IMPROVEMENT_PLANTATION
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -11029,13 +11077,23 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
+		UnitType=UNIT_GALLEON, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		PromotionType=PROMOTION_NAVIGATION1
+		PromotionType=PROMOTION_NAVIGATION2
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=La Habana
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -11384,8 +11442,8 @@ EndPlot
 BeginPlot
 	x=27,y=24
 	BonusType=BONUS_SILVER
-	ImprovementType=IMPROVEMENT_MINE
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_MINE
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -11429,10 +11487,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Bogot&#225;
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -11446,18 +11508,18 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=27,y=30
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_COFFEE
 	ImprovementType=IMPROVEMENT_PLANTATION
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=22,45,
 EndPlot
 BeginPlot
 	x=27,y=31
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=22,24,45,
@@ -11596,16 +11658,28 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=24, (England)
+		CityOwner=24
 		CityName=York
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -12205,10 +12279,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Santiago de Chile
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -12358,9 +12436,9 @@ BeginPlot
 	x=29,y=30
 	isNOfRiver
 	RiverWEDirection=1
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_COFFEE
 	ImprovementType=IMPROVEMENT_PLANTATION
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -12411,10 +12489,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=23, (France)
+		CityOwner=23
 		CityName=Port-au-Prince
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -12850,10 +12932,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Caracas
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -12972,13 +13058,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
+		UnitType=UNIT_GALLEON, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=24, (England)
+		CityOwner=24
 		CityName=New York
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -13025,16 +13119,28 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=23, (France)
+		CityOwner=23
 		CityName=Montr&#233;al
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -13261,10 +13367,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=La Paz
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -13491,10 +13601,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=24, (England)
+		CityOwner=24
 		CityName=Boston
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -13859,14 +13973,19 @@ EndPlot
 BeginPlot
 	x=32,y=37
 	BonusType=BONUS_SPICES
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=San Juan
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -14198,8 +14317,8 @@ EndPlot
 BeginPlot
 	x=33,y=20
 	BonusType=BONUS_SILVER
-	ImprovementType=IMPROVEMENT_MINE
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_MINE
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -14310,10 +14429,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=24, (England)
+		CityOwner=24
 		CityName=Bridgetown
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -14597,13 +14720,23 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
+		UnitType=UNIT_GALLEON, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		PromotionType=PROMOTION_NAVIGATION1
+		PromotionType=PROMOTION_NAVIGATION2
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Buenos Aires
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -14765,10 +14898,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=24, (England)
+		CityOwner=24
 		CityName=Georgetown
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -15522,10 +15659,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Montevideo
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -15647,8 +15788,8 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	BonusType=BONUS_SPICES
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -15816,10 +15957,14 @@ BeginPlot
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=24, (England)
+		CityOwner=24
 		CityName=St. John's
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -16107,10 +16252,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=23, (France)
+		CityOwner=23
 		CityName=Cayenne
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -16450,10 +16599,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=29, (Portugal)
+		CityOwner=29
 		CityName=S&#227;o Paulo
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -16525,8 +16678,8 @@ EndPlot
 BeginPlot
 	x=38,y=25
 	BonusType=BONUS_SPICES
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=23,29,44,
@@ -16537,10 +16690,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=29, (Portugal)
+		CityOwner=29
 		CityName=Bel&#233;m
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -16961,9 +17118,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=39,y=26
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
@@ -17723,25 +17880,37 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
+		UnitType=UNIT_GALLEON, UnitOwner=29
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
+		UnitType=UNIT_GALLEON, UnitOwner=29
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=29, (Portugal)
+		CityOwner=29
 		CityName=Rio de Janeiro
 		CityPopulation=5
+		BuildingType=BUILDING_ADMINISTRATIVE_CENTER
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_LIGHTHOUSE
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_COURTHOUSE
-		BuildingType=BUILDING_ADMINISTRATIVE_CENTER
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
 		Player29Culture=100
@@ -18193,10 +18362,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=29, (Portugal)
+		CityOwner=29
 		CityName=Recife
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -18595,9 +18768,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=43,y=23
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
@@ -19044,25 +19217,25 @@ BeginPlot
 	x=44,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=23,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=44,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=23,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=44,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=23,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=44,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=23,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=44,y=34
@@ -19124,10 +19297,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=29, (Portugal)
+		CityOwner=29
 		CityName=Ponta Delgada
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -19452,43 +19629,43 @@ BeginPlot
 	x=45,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=23,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=45,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=23,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=45,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=23,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=45,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=23,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=45,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=23,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=45,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=23,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=45,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=23,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=45,y=36
@@ -19656,10 +19833,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Reykjavik
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -19864,44 +20045,44 @@ BeginPlot
 	x=46,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=23,24,29,38,
+	TeamReveal=24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,23,24,29,38,
+	TeamReveal=22,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,23,24,29,38,
+	TeamReveal=22,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,24,29,38,
+	TeamReveal=22,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,24,29,38,
+	TeamReveal=22,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,24,29,38,
+	TeamReveal=22,24,29,38,
 EndPlot
 BeginPlot
 	x=46,y=35
 	FeatureType=FEATURE_ISLANDS, FeatureVariety=0
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,29,
+	TeamReveal=22,29,
 EndPlot
 BeginPlot
 	x=46,y=36
@@ -20253,43 +20434,43 @@ BeginPlot
 	x=47,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,24,29,38,45,
+	TeamReveal=22,24,29,38,45,
 EndPlot
 BeginPlot
 	x=47,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,24,29,38,45,
+	TeamReveal=22,24,29,38,45,
 EndPlot
 BeginPlot
 	x=47,y=31
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,24,29,38,
+	TeamReveal=22,24,29,38,
 EndPlot
 BeginPlot
 	x=47,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,24,29,38,
+	TeamReveal=22,24,29,38,
 EndPlot
 BeginPlot
 	x=47,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,24,29,38,
+	TeamReveal=22,24,29,38,
 EndPlot
 BeginPlot
 	x=47,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=47,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=47,y=36
@@ -20312,10 +20493,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=29, (Portugal)
+		CityOwner=29
 		CityName=Funchal
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -20659,20 +20844,20 @@ BeginPlot
 	x=48,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,24,29,38,45,
+	TeamReveal=22,24,29,38,45,
 EndPlot
 BeginPlot
 	x=48,y=30
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,23,24,29,38,45,
+	TeamReveal=22,24,29,38,45,
 EndPlot
 BeginPlot
 	x=48,y=31
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,23,24,29,38,45,
+	TeamReveal=22,24,29,38,45,
 EndPlot
 BeginPlot
 	x=48,y=32
@@ -20682,10 +20867,14 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=23, (France)
+		CityOwner=23
 		CityName=Saint-Louis du S&#233;n&#233;gal
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -20696,26 +20885,26 @@ BeginPlot
 		ReligionType=RELIGION_CATHOLICISM
 		Player23Culture=50
 	EndCity
-	TeamReveal=22,23,24,29,38,
+	TeamReveal=22,24,29,38,
 EndPlot
 BeginPlot
 	x=48,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,23,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=48,y=34
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,23,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=48,y=35
 	FeatureType=FEATURE_CAPE, FeatureVariety=0
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,23,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=48,y=36
@@ -20783,7 +20972,6 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,22,23,24,29,38,45,
-	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=48,y=46
@@ -21156,7 +21344,6 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,22,23,24,29,38,44,45,
-	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=49,y=41
@@ -21180,41 +21367,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=29, (Portugal)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=29, (Portugal)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=29, (Portugal)
-	EndUnit
 	BeginCity
-		CityOwner=29, (Portugal)
+		CityOwner=29
 		CityName=Lisboa
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -21263,10 +21417,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=La Coru&#241;a
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -21343,10 +21501,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=24, (England)
+		CityOwner=24
 		CityName=Dublin
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -21587,7 +21749,7 @@ BeginPlot
 	x=50,y=29
 	TerrainType=TERRAIN_PLAINS
 	PlotType=0
-	TeamReveal=22,23,24,38,44,45,
+	TeamReveal=22,24,38,44,45,
 EndPlot
 BeginPlot
 	x=50,y=30
@@ -21629,7 +21791,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	TeamReveal=22,23,29,44,45,
+	TeamReveal=22,29,44,45,
 EndPlot
 BeginPlot
 	x=50,y=36
@@ -21679,7 +21841,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,22,23,24,29,38,45,
-	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=50,y=43
@@ -21691,7 +21852,6 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=16,22,23,24,29,38,45,
-	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=50,y=44
@@ -21700,7 +21860,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,29,38,45,
-	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=50,y=45
@@ -22010,13 +22169,21 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Djenne
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -22038,19 +22205,19 @@ BeginPlot
 	x=51,y=31
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=23,45,
+	TeamReveal=45,
 EndPlot
 BeginPlot
 	x=51,y=32
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=23,45,
+	TeamReveal=45,
 EndPlot
 BeginPlot
 	x=51,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=23,44,45,
+	TeamReveal=44,45,
 EndPlot
 BeginPlot
 	x=51,y=34
@@ -22062,7 +22229,7 @@ BeginPlot
 	x=51,y=35
 	TerrainType=TERRAIN_DESERT
 	PlotType=0
-	TeamReveal=23,29,44,45,
+	TeamReveal=29,44,45,
 EndPlot
 BeginPlot
 	x=51,y=36
@@ -22077,13 +22244,21 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Marrakus
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -22126,22 +22301,50 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
+		UnitType=UNIT_GALLEON, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		PromotionType=PROMOTION_NAVIGATION1
+		PromotionType=PROMOTION_NAVIGATION2
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
+		UnitType=UNIT_GALLEON, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		PromotionType=PROMOTION_NAVIGATION1
+		PromotionType=PROMOTION_NAVIGATION2
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
+		UnitType=UNIT_GALLEON, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		PromotionType=PROMOTION_NAVIGATION1
+		PromotionType=PROMOTION_NAVIGATION2
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
+		UnitType=UNIT_GALLEON, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		PromotionType=PROMOTION_NAVIGATION1
+		PromotionType=PROMOTION_NAVIGATION2
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Sevilla
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -22622,44 +22825,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_SPANISH_CONQUISTADOR, UnitOwner=22, (Spain)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SPANISH_CONQUISTADOR, UnitOwner=22, (Spain)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SPANISH_CONQUISTADOR, UnitOwner=22, (Spain)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SPANISH_CONQUISTADOR, UnitOwner=22, (Spain)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=22, (Spain)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=22, (Spain)
-	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Madrid
 		CityPopulation=8
 		BuildingType=BUILDING_PALACE
@@ -22798,10 +22965,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=24, (England)
+		CityOwner=24
 		CityName=Edinburgh
 		CityPopulation=7
 		BuildingType=BUILDING_BARRACKS
@@ -23023,8 +23194,8 @@ EndPlot
 BeginPlot
 	x=53,y=28
 	BonusType=BONUS_GOLD
-	ImprovementType=IMPROVEMENT_MINE
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_MINE
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -23052,16 +23223,28 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Timbuktu
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -23197,22 +23380,42 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
+		UnitType=UNIT_GALLEON, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
+		UnitType=UNIT_GALLEON, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
+		UnitType=UNIT_GALLEON, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=23, (France)
+		UnitType=UNIT_GALLEON, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=23, (France)
+		CityOwner=23
 		CityName=Bordeaux
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -23276,56 +23479,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24, (England)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24, (England)
-	EndUnit
 	BeginCity
-		CityOwner=24, (England)
+		CityOwner=24
 		CityName=London
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -23337,6 +23492,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CUSTOMS_HOUSE
 		BuildingType=BUILDING_FORGE
+		BuildingType=BUILDING_ACADEMY
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_UNIVERSITY
 		BuildingType=BUILDING_THEATRE
@@ -23344,7 +23500,6 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_ENGLISH_ROYAL_EXCHANGE
 		BuildingType=BUILDING_COURTHOUSE
-		BuildingType=BUILDING_ACADEMY
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		BuildingType=BUILDING_PROTESTANT_CATHEDRAL
 		BuildingType=BUILDING_TRADING_COMPANY
@@ -23582,10 +23737,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=38, (Netherlands)
+		CityOwner=38
 		CityName=Elmina
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -23593,8 +23752,8 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
-		ReligionType=RELIGION_CATHOLICISM
 		ReligionType=RELIGION_PROTESTANTISM
+		ReligionType=RELIGION_CATHOLICISM
 		Player38Culture=50
 	EndCity
 	TeamReveal=22,24,29,38,45,
@@ -23698,10 +23857,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Wahran
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -24186,10 +24349,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Barcelona
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -24256,71 +24423,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_FRENCH_HEAVY_CANNON, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=23, (France)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=23, (France)
-	EndUnit
 	BeginCity
-		CityOwner=23, (France)
+		CityOwner=23
 		CityName=Paris
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -24329,6 +24433,7 @@ BeginPlot
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_AQUEDUCT
 		BuildingType=BUILDING_FORGE
+		BuildingType=BUILDING_ACADEMY
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_UNIVERSITY
 		BuildingType=BUILDING_AMPHITHEATRE
@@ -24337,7 +24442,6 @@ BeginPlot
 		BuildingType=BUILDING_BANK
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_FRENCH_SALON
-		BuildingType=BUILDING_ACADEMY
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_CATHEDRAL
 		BuildingType=BUILDING_TRADING_COMPANY
@@ -24626,13 +24730,21 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Gao
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -24758,10 +24870,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=23, (France)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=23
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=23, (France)
+		CityOwner=23
 		CityName=Marseille
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -25263,38 +25379,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=38, (Netherlands)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=38, (Netherlands)
-	EndUnit
 	BeginCity
-		CityOwner=38, (Netherlands)
+		CityOwner=38
 		CityName=Amsterdam
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -25314,12 +25400,12 @@ BeginPlot
 		BuildingType=BUILDING_BANK
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_DUTCH_DIKE
-		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
+		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_TRADING_COMPANY
 		ReligionType=RELIGION_JUDAISM
-		ReligionType=RELIGION_CATHOLICISM
 		ReligionType=RELIGION_PROTESTANTISM
+		ReligionType=RELIGION_CATHOLICISM
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		Player38Culture=250
@@ -25644,10 +25730,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Tunus
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -25732,7 +25822,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,38,39,44,45,
-	Player39Culture=100, (Germany)
 EndPlot
 BeginPlot
 	x=58,y=50
@@ -25758,7 +25847,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,22,23,24,25,38,39,45,
-	Player38Culture=100, (Netherlands)
 EndPlot
 BeginPlot
 	x=58,y=53
@@ -25767,7 +25855,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,22,23,24,25,38,39,44,45,
-	Player38Culture=100, (Netherlands)
 EndPlot
 BeginPlot
 	x=58,y=54
@@ -25821,13 +25908,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Bergen
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -26040,11 +26135,15 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=29, (Portugal)
-		CityName=Lagos
+		CityOwner=29
+		CityName=TXT_KEY_CITY_NAME_LAGOS
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
@@ -26081,13 +26180,21 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Ngazargamu
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -26217,13 +26324,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=25, (Holy Rome)
+		CityOwner=25
 		CityName=Mailand
 		CityPopulation=7
 		BuildingType=BUILDING_BARRACKS
@@ -26262,7 +26377,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,38,39,44,45,
-	Player39Culture=100, (Germany)
 EndPlot
 BeginPlot
 	x=59,y=50
@@ -26280,13 +26394,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=39, (Germany)
+		CityOwner=39
 		CityName=Frankfurt
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -26299,15 +26421,15 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_BANK
 		BuildingType=BUILDING_COURTHOUSE
-		BuildingType=BUILDING_MILITARY_ACADEMY
-		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		BuildingType=BUILDING_PROTESTANT_CATHEDRAL
 		BuildingType=BUILDING_PROTESTANT_SHRINE
-		ReligionType=RELIGION_JUDAISM
-		ReligionType=RELIGION_CATHOLICISM
+		BuildingType=BUILDING_CATHOLIC_TEMPLE
+		BuildingType=BUILDING_MILITARY_ACADEMY
 		ReligionType=RELIGION_PROTESTANTISM
 		HolyCityReligionType=RELIGION_PROTESTANTISM
+		ReligionType=RELIGION_JUDAISM
+		ReligionType=RELIGION_CATHOLICISM
 		Player39Culture=100
 	EndCity
 	TeamReveal=16,22,23,24,25,38,39,45,
@@ -26340,19 +26462,35 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=39, (Germany)
+		UnitType=UNIT_GALLEON, UnitOwner=39
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=39, (Germany)
+		UnitType=UNIT_GALLEON, UnitOwner=39
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=39, (Germany)
+		CityOwner=39
 		CityName=Hamburg
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -26366,8 +26504,9 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
-		ReligionType=RELIGION_CATHOLICISM
 		ReligionType=RELIGION_PROTESTANTISM
+		ReligionType=RELIGION_CATHOLICISM
+		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		Player39Culture=100
 	EndCity
@@ -26747,19 +26886,35 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Roma
 		CityPopulation=8
 		BuildingType=BUILDING_WALLS
@@ -26827,7 +26982,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,38,39,44,45,
-	Player39Culture=100, (Germany)
 EndPlot
 BeginPlot
 	x=60,y=50
@@ -26887,19 +27041,35 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK_CITY
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=K&#248;benhavn
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -26936,16 +27106,28 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Oslo
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -27159,8 +27341,8 @@ EndPlot
 BeginPlot
 	x=61,y=22
 	BonusType=BONUS_COTTON
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -27268,10 +27450,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Trablus
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -27479,13 +27665,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Trondheim
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -27648,56 +27842,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CONGOLESE_POMBOS, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CATAPULT, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CATAPULT, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_NATIVE_SLAVE, UnitOwner=37, (Congo)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SETTLER, UnitOwner=37, (Congo)
-	EndUnit
 	BeginCity
-		CityOwner=37, (Congo)
+		CityOwner=37
 		CityName=Mbanza Kongo
 		CityPopulation=8
 		BuildingType=BUILDING_PALACE
@@ -27869,10 +28015,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=25, (Holy Rome)
+		CityOwner=25
 		CityName=Neapel
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -27941,32 +28091,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=25, (Holy Rome)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=25, (Holy Rome)
-	EndUnit
 	BeginCity
-		CityOwner=25, (Holy Rome)
+		CityOwner=25
 		CityName=Wien
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -27982,10 +28108,10 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_BANK
 		BuildingType=BUILDING_HOLY_ROMAN_RATHAUS
-		BuildingType=BUILDING_MILITARY_ACADEMY
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_CATHEDRAL
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
+		BuildingType=BUILDING_MILITARY_ACADEMY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
 		Player25Culture=250
@@ -28008,7 +28134,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,26,28,38,39,45,
-	Player25Culture=100, (Holy Rome)
 EndPlot
 BeginPlot
 	x=62,y=52
@@ -28023,41 +28148,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=39, (Germany)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=39, (Germany)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=39, (Germany)
-	EndUnit
 	BeginCity
-		CityOwner=39, (Germany)
+		CityOwner=39
 		CityName=Berlin
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -28240,13 +28332,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=38, (Netherlands)
+		CityOwner=38
 		CityName=Kaapstad
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -28604,44 +28704,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=16, (Vikings)
-	EndUnit
 	BeginCity
-		CityOwner=16, (Vikings)
+		CityOwner=16
 		CityName=Stockholm
 		CityPopulation=8
 		BuildingType=BUILDING_PALACE
@@ -28845,9 +28909,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=64,y=20
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
@@ -29093,7 +29157,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,23,25,26,28,38,39,44,45,
-	Player28Culture=100, (Poland)
 EndPlot
 BeginPlot
 	x=64,y=54
@@ -29494,13 +29557,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Belgrad
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -29544,13 +29615,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=25, (Holy Rome)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=25
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=25, (Holy Rome)
+		CityOwner=25
 		CityName=Budapest
 		CityPopulation=8
 		BuildingType=BUILDING_BARRACKS
@@ -29599,44 +29678,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_POLISH_WINGED_HUSSAR, UnitOwner=28, (Poland)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=28, (Poland)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=28, (Poland)
-	EndUnit
 	BeginCity
-		CityOwner=28, (Poland)
+		CityOwner=28
 		CityName=Warszawa
 		CityPopulation=8
 		BuildingType=BUILDING_PALACE
@@ -29675,10 +29718,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=39, (Germany)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=39
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=39, (Germany)
+		CityOwner=39
 		CityName=K&#246;nigsberg
 		CityPopulation=4
 		BuildingType=BUILDING_BARRACKS
@@ -29746,10 +29793,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=16, (Vikings)
+		CityOwner=16
 		CityName=Lule&#229;
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
@@ -30203,7 +30254,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,25,26,28,39,45,
-	Player28Culture=100, (Poland)
 EndPlot
 BeginPlot
 	x=66,y=56
@@ -30543,10 +30593,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Iskenderiye
 		CityPopulation=10
 		BuildingType=BUILDING_GRANARY
@@ -30562,8 +30616,8 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_CATHEDRAL
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
-		BuildingType=BUILDING_GREAT_LIGHTHOUSE
 		BuildingType=BUILDING_GREAT_LIBRARY
+		BuildingType=BUILDING_GREAT_LIGHTHOUSE
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
@@ -30591,8 +30645,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=67,y=40
-	BonusType=BONUS_CLAM
 	ImprovementType=IMPROVEMENT_FISHING_BOATS
+	BonusType=BONUS_CLAM
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=35,44,
@@ -30603,10 +30657,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Atina
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -30727,13 +30785,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=28, (Poland)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=28
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=28, (Poland)
+		CityOwner=28
 		CityName=Wilno
 		CityPopulation=5
 		BuildingType=BUILDING_BARRACKS
@@ -30767,14 +30833,12 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,26,28,39,
-	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=67,y=58
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,26,28,39,45,
-	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=67,y=59
@@ -30784,10 +30848,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=16, (Vikings)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=16
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=16, (Vikings)
+		CityOwner=16
 		CityName=Helsingfors
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -31189,65 +31257,8 @@ BeginPlot
 	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=35, (Turkey)
-	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Kostantiniyye
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -31266,15 +31277,15 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_COURTHOUSE
-		BuildingType=BUILDING_MILITARY_ACADEMY
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_CATHEDRAL
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
+		BuildingType=BUILDING_MILITARY_ACADEMY
 		BuildingType=BUILDING_THEODOSIAN_WALLS
 		BuildingType=BUILDING_HAGIA_SOPHIA
-		BuildingType=BUILDING_BLUE_MOSQUE
 		BuildingType=BUILDING_TOPKAPI_PALACE
+		BuildingType=BUILDING_BLUE_MOSQUE
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
@@ -31379,7 +31390,6 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,26,28,39,45,
-	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=68,y=59
@@ -31387,7 +31397,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,26,28,39,45,
-	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=68,y=60
@@ -31656,10 +31665,14 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=El-Uqsur
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -31698,10 +31711,14 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=El-Kahire
 		CityPopulation=7
 		BuildingType=BUILDING_BARRACKS
@@ -31714,8 +31731,8 @@ BeginPlot
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
-		BuildingType=BUILDING_GREAT_SPHINX
 		BuildingType=BUILDING_PYRAMIDS
+		BuildingType=BUILDING_GREAT_SPHINX
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
@@ -31845,13 +31862,21 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=26, (Russia)
+		CityOwner=26
 		CityName=Kiev
 		CityPopulation=8
 		BuildingType=BUILDING_BARRACKS
@@ -31891,7 +31916,6 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=16,26,28,39,45,
-	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=69,y=55
@@ -31906,7 +31930,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,26,28,39,45,
-	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=69,y=57
@@ -31923,13 +31946,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=26, (Russia)
+		CityOwner=26
 		CityName=Sankt-Peterburg
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -32413,7 +32444,7 @@ BeginPlot
 	x=70,y=58
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=16,26,28,39,45,
+	TeamReveal=16,26,39,45,
 EndPlot
 BeginPlot
 	x=70,y=59
@@ -32423,7 +32454,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=16,26,28,39,45,
+	TeamReveal=16,26,39,45,
 EndPlot
 BeginPlot
 	x=70,y=60
@@ -32567,10 +32598,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=29, (Portugal)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=29
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=29, (Portugal)
+		CityOwner=29
 		CityName=Mo&#231;ambique
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -32619,13 +32654,21 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Mombasa
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -32798,10 +32841,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Ankara
 		CityPopulation=5
 		BuildingType=BUILDING_BARRACKS
@@ -32910,7 +32957,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=16,26,28,
+	TeamReveal=16,26,
 EndPlot
 BeginPlot
 	x=71,y=57
@@ -32925,13 +32972,13 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_VILLAGE
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=16,26,28,
+	TeamReveal=16,26,
 EndPlot
 BeginPlot
 	x=71,y=59
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=16,26,28,
+	TeamReveal=16,26,
 EndPlot
 BeginPlot
 	x=71,y=60
@@ -33168,13 +33215,21 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Gondar
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -33423,10 +33478,14 @@ BeginPlot
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=26, (Russia)
+		CityOwner=26
 		CityName=Arkhangelsk
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -33724,10 +33783,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Kud&#252;s
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -33737,19 +33800,17 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_MARKET
-		BuildingType=BUILDING_JEWISH_TEMPLE
-		BuildingType=BUILDING_JEWISH_SHRINE
+		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ORTHODOX_SHRINE
-		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
+		BuildingType=BUILDING_JEWISH_TEMPLE
+		BuildingType=BUILDING_JEWISH_SHRINE
 		BuildingType=BUILDING_DOME_OF_THE_ROCK
-		ReligionType=RELIGION_JUDAISM
-		HolyCityReligionType=RELIGION_JUDAISM
-		ReligionType=RELIGION_ORTHODOXY
-		HolyCityReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_CATHOLICISM
 		ReligionType=RELIGION_ISLAM
+		HolyCityReligionType=RELIGION_JUDAISM
+		HolyCityReligionType=RELIGION_ORTHODOXY
 		Player35Culture=200
 	EndCity
 	TeamReveal=8,35,44,
@@ -33878,56 +33939,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=26, (Russia)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=26, (Russia)
-	EndUnit
 	BeginCity
-		CityOwner=26, (Russia)
+		CityOwner=26
 		CityName=Moskva
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -33952,8 +33965,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=73,y=55
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
+	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=16,26,
@@ -33981,10 +33994,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=26, (Russia)
+		CityOwner=26
 		CityName=Vologda
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -34212,16 +34229,28 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=44, (Independent)
+		UnitType=UNIT_CANNON, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK_CITY
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Muqdisho
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -34346,10 +34375,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Sam
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -34434,13 +34467,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=26, (Russia)
+		CityOwner=26
 		CityName=Rostov-na-Donu
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -34788,10 +34829,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Mekke
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -34892,10 +34937,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Trabzon
 		CityPopulation=5
 		BuildingType=BUILDING_BARRACKS
@@ -35255,10 +35304,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Sana'a
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -35382,13 +35435,13 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_MINE
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	TeamReveal=8,26,35,44,45,
+	TeamReveal=8,35,44,45,
 EndPlot
 BeginPlot
 	x=76,y=46
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=8,26,35,44,45,
+	TeamReveal=8,35,44,45,
 EndPlot
 BeginPlot
 	x=76,y=47
@@ -35686,7 +35739,7 @@ BeginPlot
 	x=77,y=27
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,35,38,44,45,
+	TeamReveal=22,24,29,35,38,44,
 EndPlot
 BeginPlot
 	x=77,y=28
@@ -35783,10 +35836,14 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=35, (Turkey)
+		CityOwner=35
 		CityName=Baghdad
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -35945,10 +36002,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=26, (Russia)
+		CityOwner=26
 		CityName=Vyatka
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -36168,7 +36229,7 @@ BeginPlot
 	x=78,y=27
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,35,38,44,45,
+	TeamReveal=22,24,29,35,38,44,
 EndPlot
 BeginPlot
 	x=78,y=28
@@ -36283,10 +36344,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=8, (Iran)
+		CityOwner=8
 		CityName=Tabriz
 		CityPopulation=7
 		BuildingType=BUILDING_BARRACKS
@@ -36371,10 +36436,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=26, (Russia)
+		CityOwner=26
 		CityName=Samara
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -36629,7 +36698,7 @@ BeginPlot
 	x=79,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,35,38,45,
+	TeamReveal=22,24,35,38,
 EndPlot
 BeginPlot
 	x=79,y=28
@@ -36659,13 +36728,13 @@ BeginPlot
 	x=79,y=32
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,35,38,44,45,
+	TeamReveal=22,24,29,35,38,44,
 EndPlot
 BeginPlot
 	x=79,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=35,44,45,
+	TeamReveal=35,44,
 EndPlot
 BeginPlot
 	x=79,y=34
@@ -37040,43 +37109,43 @@ BeginPlot
 	x=80,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=35,45,
+	TeamReveal=35,
 EndPlot
 BeginPlot
 	x=80,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,29,35,45,
+	TeamReveal=22,29,35,
 EndPlot
 BeginPlot
 	x=80,y=29
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=22,29,35,38,45,
+	TeamReveal=22,29,35,38,
 EndPlot
 BeginPlot
 	x=80,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,35,38,44,45,
+	TeamReveal=22,24,29,35,38,44,
 EndPlot
 BeginPlot
 	x=80,y=31
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,35,38,44,45,
+	TeamReveal=22,24,29,35,38,44,
 EndPlot
 BeginPlot
 	x=80,y=32
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,35,38,44,45,
+	TeamReveal=22,24,29,35,38,44,
 EndPlot
 BeginPlot
 	x=80,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=29,35,38,44,45,
+	TeamReveal=29,35,38,44,
 EndPlot
 BeginPlot
 	x=80,y=34
@@ -37143,19 +37212,19 @@ BeginPlot
 	x=80,y=43
 	TerrainType=TERRAIN_PLAINS
 	PlotType=0
-	TeamReveal=8,34,35,44,45,
+	TeamReveal=8,34,44,45,
 EndPlot
 BeginPlot
 	x=80,y=44
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=8,35,44,45,
+	TeamReveal=8,44,45,
 EndPlot
 BeginPlot
 	x=80,y=45
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,35,44,45,
+	TeamReveal=8,44,45,
 EndPlot
 BeginPlot
 	x=80,y=46
@@ -37291,10 +37360,14 @@ BeginPlot
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=26, (Russia)
+		CityOwner=26
 		CityName=Obdorsk
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -37580,50 +37653,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=8, (Iran)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=8, (Iran)
-	EndUnit
 	BeginCity
-		CityOwner=8, (Iran)
+		CityOwner=8
 		CityName=Isfahan
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -37642,7 +37673,7 @@ BeginPlot
 		ReligionType=RELIGION_ISLAM
 		Player8Culture=250
 	EndCity
-	TeamReveal=8,34,35,44,45,
+	TeamReveal=8,34,44,45,
 EndPlot
 BeginPlot
 	x=81,y=42
@@ -37745,10 +37776,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=26, (Russia)
+		CityOwner=26
 		CityName=Ekaterinburg
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -38010,7 +38045,7 @@ BeginPlot
 	x=82,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=82,y=34
@@ -38018,16 +38053,28 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=44, (Independent)
+		UnitType=UNIT_CANNON, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK_CITY
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Masqat
 		CityPopulation=4
 		BuildingType=BUILDING_BARRACKS
@@ -38068,10 +38115,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=8, (Iran)
+		CityOwner=8
 		CityName=Shiraz
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -38123,7 +38174,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	TeamReveal=8,34,35,44,45,
+	TeamReveal=8,34,44,45,
 EndPlot
 BeginPlot
 	x=82,y=43
@@ -38550,16 +38601,28 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=44, (Independent)
+		UnitType=UNIT_CUIRASSIER, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Merv
 		CityPopulation=4
 		BuildingType=BUILDING_STABLE
@@ -38613,7 +38676,6 @@ BeginPlot
 	x=83,y=51
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=26,
 EndPlot
 BeginPlot
 	x=83,y=52
@@ -38902,31 +38964,31 @@ BeginPlot
 	x=84,y=32
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,24,29,38,44,
+	TeamReveal=24,29,38,44,
 EndPlot
 BeginPlot
 	x=84,y=33
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,22,24,29,34,38,44,
+	TeamReveal=22,24,29,34,38,44,
 EndPlot
 BeginPlot
 	x=84,y=34
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,8,22,24,29,34,38,44,
+	TeamReveal=8,22,24,29,34,38,44,
 EndPlot
 BeginPlot
 	x=84,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=5,8,22,24,29,34,38,44,45,
+	TeamReveal=8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=84,y=36
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=5,8,22,24,29,34,38,44,45,
+	TeamReveal=8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=84,y=37
@@ -38936,8 +38998,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=84,y=38
-	BonusType=BONUS_SPICES
 	ImprovementType=IMPROVEMENT_PLANTATION
+	BonusType=BONUS_SPICES
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	TeamReveal=8,24,34,44,45,
@@ -38960,10 +39022,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=8, (Iran)
+		CityOwner=8
 		CityName=Herat
 		CityPopulation=5
 		BuildingType=BUILDING_BARRACKS
@@ -39108,10 +39174,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=26, (Russia)
+		CityOwner=26
 		CityName=Tyumen
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -39353,54 +39423,61 @@ BeginPlot
 	x=85,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,29,44,
+	TeamReveal=29,44,
 EndPlot
 BeginPlot
 	x=85,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,29,44,
+	TeamReveal=29,44,
 EndPlot
 BeginPlot
 	x=85,y=32
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,24,29,44,
+	TeamReveal=24,29,44,
 EndPlot
 BeginPlot
 	x=85,y=33
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,24,29,34,44,
+	TeamReveal=24,29,34,44,
 EndPlot
 BeginPlot
 	x=85,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=5,8,24,29,34,38,44,
+	TeamReveal=8,24,29,34,38,44,
 EndPlot
 BeginPlot
 	x=85,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=5,8,22,24,29,34,38,44,45,
+	TeamReveal=8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=85,y=36
 	RiverNSDirection=2
 	isWOfRiver
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=34, (Mughals)
+		CityOwner=34
 		CityName=Kolachi
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -39413,7 +39490,7 @@ BeginPlot
 		ReligionType=RELIGION_ISLAM
 		Player34Culture=50
 	EndCity
-	TeamReveal=5,8,22,24,29,34,38,44,45,
+	TeamReveal=8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=85,y=37
@@ -39496,16 +39573,28 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=44, (Independent)
+		UnitType=UNIT_CUIRASSIER, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Samarkand
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -39803,58 +39892,58 @@ BeginPlot
 	x=86,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=10,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=86,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,10,29,
+	TeamReveal=29,
 EndPlot
 BeginPlot
 	x=86,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,10,29,44,
+	TeamReveal=29,44,
 EndPlot
 BeginPlot
 	x=86,y=32
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,10,24,29,44,45,
+	TeamReveal=24,29,44,45,
 EndPlot
 BeginPlot
 	x=86,y=33
 	BonusType=BONUS_OIL
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,10,24,29,34,38,44,45,
+	TeamReveal=24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=86,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=5,24,29,34,38,44,45,
+	TeamReveal=24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=86,y=35
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,8,22,24,29,34,38,44,45,
+	TeamReveal=8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=86,y=36
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,8,22,24,34,38,44,45,
+	TeamReveal=8,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=86,y=37
+	RouteType=ROUTE_ROAD
 	ImprovementType=IMPROVEMENT_HAMLET
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	TeamReveal=8,22,24,34,38,44,45,
@@ -39875,8 +39964,8 @@ BeginPlot
 	x=86,y=39
 	RiverNSDirection=2
 	isWOfRiver
-	BonusType=BONUS_MARBLE
 	ImprovementType=IMPROVEMENT_QUARRY
+	BonusType=BONUS_MARBLE
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=8,24,34,44,45,
@@ -40210,75 +40299,74 @@ BeginPlot
 	x=87,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=10,
 EndPlot
 BeginPlot
 	x=87,y=28
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=10,29,44,
+	TeamReveal=29,44,
 EndPlot
 BeginPlot
 	x=87,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=10,29,44,
+	TeamReveal=29,44,
 EndPlot
 BeginPlot
 	x=87,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,10,29,34,44,45,
+	TeamReveal=29,34,44,45,
 EndPlot
 BeginPlot
 	x=87,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=5,10,29,34,44,45,
+	TeamReveal=29,34,44,45,
 EndPlot
 BeginPlot
 	x=87,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=5,10,24,29,34,44,45,
+	TeamReveal=24,29,34,44,45,
 EndPlot
 BeginPlot
 	x=87,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=5,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=5,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=36
-	BonusType=BONUS_COTTON
 	ImprovementType=IMPROVEMENT_PLANTATION
+	BonusType=BONUS_COTTON
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=5,8,22,24,34,38,44,45,
+	TeamReveal=8,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=37
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=5,8,22,24,34,38,44,45,
+	TeamReveal=8,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=38
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=5,8,24,34,44,45,
+	TeamReveal=8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=87,y=39
@@ -40295,10 +40383,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=34, (Mughals)
+		CityOwner=34
 		CityName=Lahore
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -40644,104 +40736,55 @@ BeginPlot
 	x=88,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=10,44,
+	TeamReveal=44,
 EndPlot
 BeginPlot
 	x=88,y=28
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=10,29,38,44,
+	TeamReveal=29,38,44,
 EndPlot
 BeginPlot
 	x=88,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=10,29,38,44,
+	TeamReveal=29,38,44,
 EndPlot
 BeginPlot
 	x=88,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=31
-	BonusType=BONUS_FISH
 	ImprovementType=IMPROVEMENT_FISHING_BOATS
+	BonusType=BONUS_FISH
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=33
-	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	BonusType=BONUS_BANANA
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=34
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
-	EndUnit
 	BeginCity
-		CityOwner=5, (India)
+		CityOwner=5
 		CityName=Mumbai
 		CityPopulation=6
 		BuildingType=BUILDING_PALACE
@@ -40749,17 +40792,16 @@ BeginPlot
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_LIBRARY
+		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_THEATRE
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_HINDU_TEMPLE
 		BuildingType=BUILDING_HINDU_MONASTERY
 		ReligionType=RELIGION_HINDUISM
-		FreeSpecialistType=SPECIALIST_GREAT_GENERAL
 		Player5Culture=75
 	EndCity
-	TeamReveal=5,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=35
@@ -40768,7 +40810,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=5,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=36
@@ -40776,22 +40818,22 @@ BeginPlot
 	RiverWEDirection=3
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=5,22,24,34,38,44,45,
+	TeamReveal=22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=37
-	BonusType=BONUS_HORSE
-	ImprovementType=IMPROVEMENT_PASTURE
 	RouteType=ROUTE_ROAD
+	ImprovementType=IMPROVEMENT_PASTURE
+	BonusType=BONUS_HORSE
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=5,22,24,34,38,44,45,
+	TeamReveal=22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=38
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=5,8,24,34,44,45,
+	TeamReveal=8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=88,y=39
@@ -40799,7 +40841,7 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=5,8,24,34,44,45,
+	TeamReveal=8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=88,y=40
@@ -40809,16 +40851,16 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=88,y=41
-	BonusType=BONUS_SUGAR
 	ImprovementType=IMPROVEMENT_PLANTATION
+	BonusType=BONUS_SUGAR
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=8,34,44,45,
 EndPlot
 BeginPlot
 	x=88,y=42
-	BonusType=BONUS_WHEAT
 	ImprovementType=IMPROVEMENT_FARM
+	BonusType=BONUS_WHEAT
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=8,34,44,45,
@@ -41139,65 +41181,65 @@ BeginPlot
 	x=89,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=10,38,44,
+	TeamReveal=38,44,
 EndPlot
 BeginPlot
 	x=89,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,29,38,44,
+	TeamReveal=22,29,38,44,
 EndPlot
 BeginPlot
 	x=89,y=29
-	BonusType=BONUS_PEARL
 	ImprovementType=IMPROVEMENT_FISHING_BOATS
+	BonusType=BONUS_PEARL
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=89,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=31
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=32
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=33
-	BonusType=BONUS_GEMS
-	ImprovementType=IMPROVEMENT_MINE
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
+	ImprovementType=IMPROVEMENT_MINE
+	BonusType=BONUS_GEMS
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=34
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=35
+	RouteType=ROUTE_ROAD
 	isNOfRiver
 	RiverWEDirection=3
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=36
@@ -41208,31 +41250,31 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=5,24,34,38,44,45,
+	TeamReveal=24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=37
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=89,y=38
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=89,y=39
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=5,8,24,34,44,45,
+	TeamReveal=8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=89,y=40
-	BonusType=BONUS_COW
 	ImprovementType=IMPROVEMENT_PASTURE
+	BonusType=BONUS_COW
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=8,34,44,
@@ -41257,7 +41299,6 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=34,44,
 EndPlot
 BeginPlot
 	x=89,y=44
@@ -41285,13 +41326,21 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Kashgar
 		CityPopulation=4
 		BuildingType=BUILDING_WALLS
@@ -41387,10 +41436,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=26, (Russia)
+		CityOwner=26
 		CityName=Tomsk
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -41605,142 +41658,119 @@ BeginPlot
 	x=90,y=27
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,38,44,
+	TeamReveal=38,44,
 EndPlot
 BeginPlot
 	x=90,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=90,y=29
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=10,22,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=90,y=30
 	RiverNSDirection=2
 	isWOfRiver
-	BonusType=BONUS_GOLD
 	ImprovementType=IMPROVEMENT_MINE
+	BonusType=BONUS_GOLD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=31
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=10, (Tamils)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=10, (Tamils)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=10, (Tamils)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=10, (Tamils)
-	EndUnit
 	BeginCity
-		CityOwner=10, (Tamils)
+		CityOwner=10
 		CityName=Mahishuru
 		CityPopulation=5
 		BuildingType=BUILDING_PALACE
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_BARRACKS
+		BuildingType=BUILDING_TAMIL_SANGAM
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_FORGE
-		BuildingType=BUILDING_TAMIL_SANGAM
 		BuildingType=BUILDING_HINDU_TEMPLE
 		BuildingType=BUILDING_HINDU_MONASTERY
-		ReligionType=RELIGION_ISLAM
 		ReligionType=RELIGION_HINDUISM
+		ReligionType=RELIGION_ISLAM
 		Player10Culture=50
 	EndCity
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=32
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=33
 	isNOfRiver
 	RiverWEDirection=1
-	BonusType=BONUS_SUGAR
 	ImprovementType=IMPROVEMENT_PLANTATION
+	BonusType=BONUS_SUGAR
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,10,24,29,34,38,44,45,
+	TeamReveal=24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=34
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,10,24,29,34,38,44,45,
+	TeamReveal=24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=35
-	BonusType=BONUS_RICE
 	ImprovementType=IMPROVEMENT_FARM
+	BonusType=BONUS_RICE
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,29,34,38,44,45,
+	TeamReveal=24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=36
+	RouteType=ROUTE_ROAD
 	BonusType=BONUS_COTTON
 	ImprovementType=IMPROVEMENT_PLANTATION
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=5,24,34,38,44,45,
+	TeamReveal=24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=37
 	isNOfRiver
 	RiverWEDirection=3
-	RouteType=ROUTE_ROAD
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=5, (India)
+		CityOwner=5
 		CityName=Bhopal
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -41751,59 +41781,32 @@ BeginPlot
 		ReligionType=RELIGION_HINDUISM
 		Player5Culture=75
 	EndCity
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=90,y=38
+	RouteType=ROUTE_ROAD
 	BonusType=BONUS_WHEAT
 	ImprovementType=IMPROVEMENT_FARM
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=90,y=39
-	BonusType=BONUS_IVORY
 	ImprovementType=IMPROVEMENT_CAMP
+	BonusType=BONUS_IVORY
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=5,8,24,34,44,45,
+	TeamReveal=8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=90,y=40
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUGHAL_SIEGE_ELEPHANT, UnitOwner=34, (Mughals)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUGHAL_SIEGE_ELEPHANT, UnitOwner=34, (Mughals)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=34, (Mughals)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=34, (Mughals)
-	EndUnit
 	BeginCity
-		CityOwner=34, (Mughals)
+		CityOwner=34
 		CityName=Delhi
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -41817,13 +41820,13 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_CATHEDRAL
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
-		BuildingType=BUILDING_RED_FORT
 		BuildingType=BUILDING_TAJ_MAHAL
+		BuildingType=BUILDING_RED_FORT
 		ReligionType=RELIGION_ISLAM
 		ReligionType=RELIGION_HINDUISM
 		Player34Culture=250
 	EndCity
-	TeamReveal=5,8,24,34,44,45,
+	TeamReveal=8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=90,y=41
@@ -42154,22 +42157,22 @@ BeginPlot
 	x=91,y=27
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,29,38,44,
+	TeamReveal=29,38,44,
 EndPlot
 BeginPlot
 	x=91,y=28
-	BonusType=BONUS_COW
 	ImprovementType=IMPROVEMENT_PASTURE
+	BonusType=BONUS_COW
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=10,22,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=91,y=29
 	BonusType=BONUS_ALUMINUM
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=10,22,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=91,y=30
@@ -42178,52 +42181,63 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=31
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=32
-	BonusType=BONUS_SPICES
-	ImprovementType=IMPROVEMENT_PLANTATION
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
+	BonusType=BONUS_SPICES
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=33
 	isNOfRiver
 	RiverWEDirection=1
-	BonusType=BONUS_IVORY
 	ImprovementType=IMPROVEMENT_CAMP
+	BonusType=BONUS_IVORY
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=34
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Hyderabad
 		CityPopulation=7
 		BuildingType=BUILDING_WALLS
@@ -42238,7 +42252,7 @@ BeginPlot
 		ReligionType=RELIGION_HINDUISM
 		Player45Culture=200
 	EndCity
-	TeamReveal=5,10,24,29,34,38,44,45,
+	TeamReveal=24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=35
@@ -42250,7 +42264,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,29,34,38,44,45,
+	TeamReveal=24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=36
@@ -42258,7 +42272,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,34,38,44,45,
+	TeamReveal=24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=37
@@ -42268,14 +42282,14 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_MINE
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=91,y=38
 	FeatureType=FEATURE_JUNGLE, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=91,y=39
@@ -42284,18 +42298,18 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,8,24,34,44,45,
+	TeamReveal=8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=91,y=40
 	RiverNSDirection=2
 	isWOfRiver
-	BonusType=BONUS_DYE
 	ImprovementType=IMPROVEMENT_PLANTATION
+	BonusType=BONUS_DYE
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,8,24,34,44,45,
+	TeamReveal=8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=91,y=41
@@ -42328,8 +42342,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=91,y=45
-	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_VILLAGE
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	TeamReveal=1,44,
@@ -42629,62 +42643,85 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=92,y=27
-	BonusType=BONUS_PEARL
 	ImprovementType=IMPROVEMENT_FISHING_BOATS
+	BonusType=BONUS_PEARL
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=92,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=92,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=92,y=30
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=31
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=32
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+		UnitType=UNIT_CANNON, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK_CITY
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+		UnitType=UNIT_CANNON, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK_CITY
 	EndUnit
 	BeginCity
-		CityOwner=24, (England)
+		CityOwner=24
 		CityName=Madras
 		CityPopulation=5
 		BuildingType=BUILDING_WALLS
@@ -42699,7 +42736,7 @@ BeginPlot
 		ReligionType=RELIGION_HINDUISM
 		Player24Culture=50
 	EndCity
-	TeamReveal=10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=33
@@ -42708,7 +42745,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=34
@@ -42717,7 +42754,7 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=35
@@ -42727,14 +42764,14 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,34,38,44,45,
+	TeamReveal=24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=36
 	FeatureType=FEATURE_JUNGLE, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,34,38,44,45,
+	TeamReveal=24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=37
@@ -42743,7 +42780,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=38
@@ -42753,14 +42790,14 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=39
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=40
@@ -42770,14 +42807,14 @@ BeginPlot
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=41
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,5,24,34,44,45,
+	TeamReveal=1,24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=42
@@ -43091,23 +43128,27 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=93,y=27
-	BonusType=BONUS_IRON
 	ImprovementType=IMPROVEMENT_MINE
+	BonusType=BONUS_IRON
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=10,22,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=93,y=28
 	BonusType=BONUS_SPICES
-	RouteType=ROUTE_ROAD
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=38, (Netherlands)
+		CityOwner=38
 		CityName=Colombo
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -43122,39 +43163,39 @@ BeginPlot
 		ReligionType=RELIGION_BUDDHISM
 		Player38Culture=50
 	EndCity
-	TeamReveal=10,22,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=93,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=93,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=31
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=33
-	BonusType=BONUS_COW
 	ImprovementType=IMPROVEMENT_PASTURE
+	BonusType=BONUS_COW
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=34
@@ -43162,7 +43203,7 @@ BeginPlot
 	RiverWEDirection=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=5,10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=35
@@ -43170,7 +43211,7 @@ BeginPlot
 	FeatureType=FEATURE_JUNGLE, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=5,10,24,29,34,38,44,45,
+	TeamReveal=24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=36
@@ -43178,7 +43219,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,34,38,44,45,
+	TeamReveal=24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=37
@@ -43187,7 +43228,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,34,38,45,
+	TeamReveal=24,34,38,45,
 EndPlot
 BeginPlot
 	x=93,y=38
@@ -43196,13 +43237,13 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	TeamReveal=5,24,34,38,44,45,
+	TeamReveal=24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=39
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=93,y=40
@@ -43212,13 +43253,13 @@ BeginPlot
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=93,y=41
 	TerrainType=TERRAIN_GRASS
 	PlotType=0
-	TeamReveal=1,5,24,34,44,45,
+	TeamReveal=1,24,34,44,45,
 EndPlot
 BeginPlot
 	x=93,y=42
@@ -43261,8 +43302,8 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	ImprovementType=IMPROVEMENT_VILLAGE
-	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	RouteType=ROUTE_ROAD
+	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	TeamReveal=1,44,
@@ -43528,8 +43569,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=94,y=27
-	BonusType=BONUS_FISH
 	ImprovementType=IMPROVEMENT_FISHING_BOATS
+	BonusType=BONUS_FISH
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=22,24,29,38,
@@ -43538,39 +43579,39 @@ BeginPlot
 	x=94,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,38,
+	TeamReveal=22,24,29,38,
 EndPlot
 BeginPlot
 	x=94,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,38,
+	TeamReveal=22,24,29,38,
 EndPlot
 BeginPlot
 	x=94,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=10,22,24,29,38,44,
+	TeamReveal=22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=94,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=10,24,29,34,38,44,45,
+	TeamReveal=24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=94,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=94,y=33
-	BonusType=BONUS_FISH
 	ImprovementType=IMPROVEMENT_FISHING_BOATS
+	BonusType=BONUS_FISH
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=10,22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=94,y=34
@@ -43588,8 +43629,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=94,y=36
-	BonusType=BONUS_TEA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	BonusType=BONUS_TEA
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -43599,8 +43640,8 @@ BeginPlot
 	x=94,y=37
 	isNOfRiver
 	RiverWEDirection=1
-	BonusType=BONUS_COTTON
 	ImprovementType=IMPROVEMENT_PLANTATION
+	BonusType=BONUS_COTTON
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=22,24,29,34,38,44,45,
@@ -43615,11 +43656,11 @@ EndPlot
 BeginPlot
 	x=94,y=39
 	BonusType=BONUS_DYE
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=94,y=40
@@ -43629,13 +43670,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=34, (Mughals)
+		CityOwner=34
 		CityName=Azimabad
 		CityPopulation=10
 		BuildingType=BUILDING_STABLE
@@ -43658,7 +43707,7 @@ BeginPlot
 		FreeSpecialistType=SPECIALIST_GREAT_PRIEST
 		Player34Culture=200
 	EndCity
-	TeamReveal=5,24,34,44,45,
+	TeamReveal=24,34,44,45,
 EndPlot
 BeginPlot
 	x=94,y=41
@@ -43710,13 +43759,21 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=44, (Independent)
+		UnitType=UNIT_CUIRASSIER, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Turfan
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -44006,13 +44063,13 @@ BeginPlot
 	x=95,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,38,44,45,
+	TeamReveal=24,38,44,
 EndPlot
 BeginPlot
 	x=95,y=32
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,38,44,45,
+	TeamReveal=22,24,38,44,
 EndPlot
 BeginPlot
 	x=95,y=33
@@ -44030,51 +44087,90 @@ BeginPlot
 	x=95,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,38,44,45,
 EndPlot
 BeginPlot
 	x=95,y=36
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,38,44,45,
 EndPlot
 BeginPlot
 	x=95,y=37
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
+		UnitType=UNIT_GALLEON, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
+		UnitType=UNIT_GALLEON, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+		UnitType=UNIT_CANNON, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK_CITY
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+		UnitType=UNIT_CANNON, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK_CITY
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24, (England)
+		UnitType=UNIT_CANNON, UnitOwner=24
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK_CITY
 	EndUnit
 	BeginCity
-		CityOwner=24, (England)
+		CityOwner=24
 		CityName=Calcutta
 		CityPopulation=6
 		BuildingType=BUILDING_WALLS
@@ -44104,8 +44200,8 @@ BeginPlot
 	x=95,y=39
 	RiverNSDirection=2
 	isWOfRiver
-	BonusType=BONUS_BANANA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	BonusType=BONUS_BANANA
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -44115,8 +44211,8 @@ BeginPlot
 	x=95,y=40
 	isNOfRiver
 	RiverWEDirection=1
-	BonusType=BONUS_TEA
 	ImprovementType=IMPROVEMENT_PLANTATION
+	BonusType=BONUS_TEA
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -44478,14 +44574,14 @@ BeginPlot
 	x=96,y=35
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,29,34,36,38,44,45,
+	TeamReveal=22,24,29,36,38,44,45,
 EndPlot
 BeginPlot
 	x=96,y=36
-	BonusType=BONUS_FISH
 	TerrainType=TERRAIN_COAST
+	BonusType=BONUS_FISH
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=22,24,29,38,44,45,
 EndPlot
 BeginPlot
 	x=96,y=37
@@ -44546,10 +44642,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (China)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (China)
+		CityOwner=44
 		CityName=Lasa
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -44584,8 +44684,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=96,y=47
-	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_VILLAGE
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	TeamReveal=1,44,
@@ -44904,13 +45004,13 @@ BeginPlot
 	x=97,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=1,22,24,29,34,36,38,44,45,
+	TeamReveal=1,22,24,29,36,38,44,45,
 EndPlot
 BeginPlot
 	x=97,y=36
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=1,22,24,29,34,38,44,45,
+	TeamReveal=1,22,24,29,38,44,45,
 EndPlot
 BeginPlot
 	x=97,y=37
@@ -45313,16 +45413,28 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Yangon
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -45338,7 +45450,7 @@ BeginPlot
 		ReligionType=RELIGION_BUDDHISM
 		Player44Culture=100
 	EndCity
-	TeamReveal=1,22,24,29,34,36,38,44,45,
+	TeamReveal=1,22,24,29,36,38,44,45,
 EndPlot
 BeginPlot
 	x=98,y=37
@@ -45367,14 +45479,14 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=1,24,34,44,45,
+	TeamReveal=1,34,44,45,
 EndPlot
 BeginPlot
 	x=98,y=40
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,24,34,44,45,
+	TeamReveal=1,34,44,45,
 EndPlot
 BeginPlot
 	x=98,y=41
@@ -45709,8 +45821,8 @@ EndPlot
 BeginPlot
 	x=99,y=28
 	BonusType=BONUS_SUGAR
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -45763,8 +45875,8 @@ EndPlot
 BeginPlot
 	x=99,y=36
 	BonusType=BONUS_BANANA
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -45773,8 +45885,8 @@ EndPlot
 BeginPlot
 	x=99,y=37
 	BonusType=BONUS_TEA
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -45796,7 +45908,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,24,34,44,45,
+	TeamReveal=1,34,44,45,
 EndPlot
 BeginPlot
 	x=99,y=40
@@ -45805,7 +45917,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,24,34,44,45,
+	TeamReveal=1,34,44,45,
 EndPlot
 BeginPlot
 	x=99,y=41
@@ -45815,10 +45927,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=1, (China)
+		CityOwner=1
 		CityName=Chengdu
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -46146,16 +46262,28 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Palembang
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -46172,8 +46300,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=100,y=27
-	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_VILLAGE
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=29,38,44,45,
@@ -46193,8 +46321,8 @@ EndPlot
 BeginPlot
 	x=100,y=30
 	BonusType=BONUS_SUGAR
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -46203,8 +46331,8 @@ EndPlot
 BeginPlot
 	x=100,y=31
 	BonusType=BONUS_DYE
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -46213,8 +46341,8 @@ EndPlot
 BeginPlot
 	x=100,y=32
 	BonusType=BONUS_SPICES
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -46225,8 +46353,8 @@ BeginPlot
 	RiverNSDirection=2
 	isWOfRiver
 	BonusType=BONUS_BANANA
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -46322,10 +46450,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=1, (China)
+		CityOwner=1
 		CityName=Xi'an
 		CityPopulation=8
 		BuildingType=BUILDING_BARRACKS
@@ -46658,13 +46790,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=38, (Netherlands)
+		CityOwner=38
 		CityName=Malakka
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -46707,44 +46847,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_THAI_CHANG_SUEK, UnitOwner=36, (Thailand)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_THAI_CHANG_SUEK, UnitOwner=36, (Thailand)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_THAI_CHANG_SUEK, UnitOwner=36, (Thailand)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_THAI_CHANG_SUEK, UnitOwner=36, (Thailand)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=36, (Thailand)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=36, (Thailand)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=36, (Thailand)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=36, (Thailand)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=36, (Thailand)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=36, (Thailand)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=36, (Thailand)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=36, (Thailand)
-	EndUnit
 	BeginCity
-		CityOwner=36, (Thailand)
+		CityOwner=36
 		CityName=Ayutthaya
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -46803,19 +46907,35 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Hanoi
 		CityPopulation=7
 		BuildingType=BUILDING_GRANARY
@@ -46836,8 +46956,8 @@ EndPlot
 BeginPlot
 	x=101,y=38
 	BonusType=BONUS_TEA
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -47272,8 +47392,8 @@ EndPlot
 BeginPlot
 	x=102,y=38
 	BonusType=BONUS_BANANA
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -47302,10 +47422,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=1, (China)
+		CityOwner=1
 		CityName=Chongqing
 		CityPopulation=7
 		BuildingType=BUILDING_GRANARY
@@ -47371,62 +47495,12 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
-	EndUnit
 	BeginCity
-		CityOwner=1, (China)
+		CityOwner=1
 		CityName=Beijing
 		CityPopulation=9
 		BuildingType=BUILDING_PALACE
+		BuildingType=BUILDING_FORBIDDEN_PALACE
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
@@ -47438,7 +47512,6 @@ BeginPlot
 		BuildingType=BUILDING_CONFUCIAN_MONASTERY
 		BuildingType=BUILDING_TAOIST_TEMPLE
 		BuildingType=BUILDING_GREAT_WALL
-		BuildingType=BUILDING_FORBIDDEN_PALACE
 		ReligionType=RELIGION_CONFUCIANISM
 		ReligionType=RELIGION_TAOISM
 		Player1Culture=150
@@ -47761,7 +47834,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,22,29,36,38,44,
+	TeamReveal=1,22,29,36,38,
 EndPlot
 BeginPlot
 	x=103,y=34
@@ -47775,8 +47848,8 @@ EndPlot
 BeginPlot
 	x=103,y=35
 	BonusType=BONUS_DYE
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=1,22,29,36,38,44,45,
@@ -47798,8 +47871,8 @@ EndPlot
 BeginPlot
 	x=103,y=38
 	BonusType=BONUS_SILK
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -47852,10 +47925,14 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=1, (China)
+		CityOwner=1
 		CityName=Kaifeng
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -47953,14 +48030,13 @@ BeginPlot
 	x=103,y=54
 	TerrainType=TERRAIN_GRASS
 	PlotType=0
-	TeamReveal=1,44,
+	TeamReveal=1,
 EndPlot
 BeginPlot
 	x=103,y=55
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=103,y=56
@@ -48177,19 +48253,35 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=38, (Netherlands)
+		CityOwner=38
 		CityName=Batavia
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -48215,8 +48307,8 @@ EndPlot
 BeginPlot
 	x=104,y=27
 	BonusType=BONUS_BANANA
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -48226,20 +48318,33 @@ BeginPlot
 	x=104,y=28
 	isNOfRiver
 	RiverWEDirection=3
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Pontianak
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -48282,20 +48387,31 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=104,y=33
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Saigon
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -48311,7 +48427,7 @@ BeginPlot
 		ReligionType=RELIGION_CONFUCIANISM
 		Player44Culture=50
 	EndCity
-	TeamReveal=1,22,29,36,38,44,
+	TeamReveal=1,22,29,36,38,
 EndPlot
 BeginPlot
 	x=104,y=34
@@ -48481,7 +48597,7 @@ BeginPlot
 	x=104,y=55
 	TerrainType=TERRAIN_GRASS
 	PlotType=0
-	TeamReveal=1,44,
+	TeamReveal=1,
 EndPlot
 BeginPlot
 	x=104,y=56
@@ -48708,8 +48824,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=105,y=27
-	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_VILLAGE
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -48751,11 +48867,11 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=105,y=33
-	BonusType=BONUS_CLAM
 	ImprovementType=IMPROVEMENT_FISHING_BOATS
+	BonusType=BONUS_CLAM
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,29,36,44,
+	TeamReveal=22,29,36,
 EndPlot
 BeginPlot
 	x=105,y=34
@@ -48793,13 +48909,18 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=1, (China)
+		CityOwner=1
 		CityName=Guangzhou
 		CityPopulation=10
 		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_LIGHTHOUSE
 		BuildingType=BUILDING_HARBOR
@@ -48816,8 +48937,8 @@ EndPlot
 BeginPlot
 	x=105,y=40
 	BonusType=BONUS_BANANA
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=1,22,29,45,
@@ -48890,13 +49011,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=1, (China)
+		CityOwner=1
 		CityName=Shenyang
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -48951,7 +49080,6 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
-	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=105,y=56
@@ -49161,8 +49289,8 @@ EndPlot
 BeginPlot
 	x=106,y=25
 	BonusType=BONUS_SPICES
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -49246,7 +49374,7 @@ BeginPlot
 	x=106,y=37
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=1,22,29,44,45,
+	TeamReveal=1,22,29,45,
 EndPlot
 BeginPlot
 	x=106,y=38
@@ -49304,10 +49432,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=1, (China)
+		CityOwner=1
 		CityName=Shanghai
 		CityPopulation=10
 		BuildingType=BUILDING_GRANARY
@@ -49373,8 +49505,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=106,y=51
-	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	RouteType=ROUTE_ROAD
+	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=1,12,44,45,
@@ -49400,21 +49532,19 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=1,44,
+	TeamReveal=1,
 EndPlot
 BeginPlot
 	x=106,y=55
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
-	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=106,y=56
 	FeatureType=FEATURE_FOREST, FeatureVariety=2
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
-	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=106,y=57
@@ -49611,8 +49741,8 @@ EndPlot
 BeginPlot
 	x=107,y=24
 	BonusType=BONUS_BANANA
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -49694,7 +49824,7 @@ BeginPlot
 	x=107,y=37
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=1,15,22,29,44,45,
+	TeamReveal=1,15,22,29,45,
 EndPlot
 BeginPlot
 	x=107,y=38
@@ -49729,10 +49859,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=1, (China)
+		CityOwner=1
 		CityName=Hangzhou
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -49817,23 +49951,26 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=107,y=52
+	RouteType=ROUTE_ROAD
 	BonusType=BONUS_OIL
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=1,12,44,
 EndPlot
 BeginPlot
 	x=107,y=53
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (China)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=44, (China)
+		CityOwner=44
 		CityName=Qiqihar
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -49852,7 +49989,7 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=1,44,
+	TeamReveal=1,
 EndPlot
 BeginPlot
 	x=107,y=55
@@ -49860,7 +49997,6 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=107,y=56
@@ -49868,7 +50004,6 @@ BeginPlot
 	isWOfRiver
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=0
-	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=107,y=57
@@ -50078,20 +50213,33 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=108,y=26
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Makassar
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -50154,8 +50302,8 @@ EndPlot
 BeginPlot
 	x=108,y=34
 	BonusType=BONUS_SUGAR
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -50255,13 +50403,21 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=12, (Korea)
+		CityOwner=12
 		CityName=Pyongyang
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -50327,20 +50483,18 @@ BeginPlot
 	FeatureType=FEATURE_MARSH, FeatureVariety=0
 	TerrainType=TERRAIN_MARSH
 	PlotType=2
-	TeamReveal=1,44,
+	TeamReveal=1,
 EndPlot
 BeginPlot
 	x=108,y=55
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=108,y=56
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=0
-	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=108,y=57
@@ -50552,8 +50706,8 @@ EndPlot
 BeginPlot
 	x=109,y=26
 	BonusType=BONUS_SPICES
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -50605,13 +50759,23 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
+		UnitType=UNIT_GALLEON, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		PromotionType=PROMOTION_NAVIGATION1
+		PromotionType=PROMOTION_NAVIGATION2
+		FacingDirection=4
+		UnitAIType=UNITAI_ASSAULT_SEA
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=22, (Spain)
+		CityOwner=22
 		CityName=Manila
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -50629,8 +50793,8 @@ EndPlot
 BeginPlot
 	x=109,y=34
 	BonusType=BONUS_BANANA
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -50711,38 +50875,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=12, (Korea)
-	EndUnit
 	BeginCity
-		CityOwner=12, (Korea)
+		CityOwner=12
 		CityName=Hanseong
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -50825,21 +50959,19 @@ BeginPlot
 	FeatureType=FEATURE_MARSH, FeatureVariety=0
 	TerrainType=TERRAIN_MARSH
 	PlotType=2
-	TeamReveal=1,44,
+	TeamReveal=1,
 EndPlot
 BeginPlot
 	x=109,y=55
 	FeatureType=FEATURE_FOREST, FeatureVariety=2
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
-	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=109,y=56
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=1
-	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=109,y=57
@@ -51082,8 +51214,8 @@ EndPlot
 BeginPlot
 	x=110,y=31
 	BonusType=BONUS_SILK
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -51237,7 +51369,7 @@ BeginPlot
 	FeatureType=FEATURE_MARSH, FeatureVariety=0
 	TerrainType=TERRAIN_MARSH
 	PlotType=2
-	TeamReveal=1,15,44,
+	TeamReveal=1,15,
 EndPlot
 BeginPlot
 	x=110,y=54
@@ -51246,7 +51378,7 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=1
-	TeamReveal=1,15,44,
+	TeamReveal=1,15,
 EndPlot
 BeginPlot
 	x=110,y=55
@@ -51464,8 +51596,8 @@ EndPlot
 BeginPlot
 	x=111,y=26
 	BonusType=BONUS_DYE
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -51474,14 +51606,19 @@ EndPlot
 BeginPlot
 	x=111,y=27
 	BonusType=BONUS_SPICES
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_CITY_DEFENSE
 	EndUnit
 	BeginCity
-		CityOwner=38, (Netherlands)
+		CityOwner=38
 		CityName=Ambon
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -51973,10 +52110,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=15, (Japan)
+		CityOwner=15
 		CityName=Kagoshima
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -52307,8 +52448,8 @@ EndPlot
 BeginPlot
 	x=113,y=27
 	BonusType=BONUS_SPICES
-	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=38,
@@ -52421,53 +52562,8 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BOMBARD, UnitOwner=15, (Japan)
-	EndUnit
-(	BeginUnit)
-(		UnitType=UNIT_SETTLER, UnitOwner=15, (Japan)) (AI only)
-(	EndUnit)
 	BeginCity
-		CityOwner=15, (Japan)
+		CityOwner=15
 		CityName=Kyouto
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -53707,10 +53803,14 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15
+		Damage=0
+		Level=1, Experience=0
+		FacingDirection=4
+		UnitAIType=UNITAI_ATTACK
 	EndUnit
 	BeginCity
-		CityOwner=15, (Japan)
+		CityOwner=15
 		CityName=Edo
 		CityPopulation=12
 		BuildingType=BUILDING_GRANARY
@@ -56367,3 +56467,5 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 EndPlot
+
+### Sign Info ###

--- a/PrivateMaps/RFC 1700 AD.CivBeyondSwordWBSave
+++ b/PrivateMaps/RFC 1700 AD.CivBeyondSwordWBSave
@@ -6416,7 +6416,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,45,
 EndPlot
@@ -6808,7 +6808,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,45,
 EndPlot
@@ -7594,7 +7594,7 @@ BeginPlot
 		BuildingType=BUILDING_CATHOLIC_CATHEDRAL
 		BuildingType=BUILDING_FLOATING_GARDENS
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=100
+		Player22Culture=100, (Spain)
 	EndCity
 	TeamReveal=22,45,
 EndPlot
@@ -7629,7 +7629,7 @@ BeginPlot
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,23,45,
 EndPlot
@@ -9280,7 +9280,7 @@ BeginPlot
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player23Culture=50
+		Player23Culture=50, (France)
 	EndCity
 	TeamReveal=23,45,
 EndPlot
@@ -9648,7 +9648,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,24,44,
 EndPlot
@@ -9694,7 +9694,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_TEMPLE_OF_KUKULKAN
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,23,24,44,45,
 EndPlot
@@ -10068,7 +10068,7 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,45,
 EndPlot
@@ -10613,7 +10613,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player24Culture=50
+		Player24Culture=50, (England)
 	EndCity
 	TeamReveal=23,24,44,45,
 EndPlot
@@ -10911,7 +10911,7 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_COURTHOUSE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=100
+		Player22Culture=100, (Spain)
 	EndCity
 	TeamReveal=22,45,
 EndPlot
@@ -11045,7 +11045,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,23,24,45,
 EndPlot
@@ -11440,7 +11440,7 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,45,
 EndPlot
@@ -11613,7 +11613,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player24Culture=50
+		Player24Culture=50, (England)
 	EndCity
 	TeamReveal=23,24,44,
 EndPlot
@@ -12216,7 +12216,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,45,
 EndPlot
@@ -12424,7 +12424,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player23Culture=50
+		Player23Culture=50, (France)
 	EndCity
 	TeamReveal=22,23,24,45,
 EndPlot
@@ -12861,7 +12861,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,23,24,44,45,
 EndPlot
@@ -12989,7 +12989,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player24Culture=50
+		Player24Culture=50, (England)
 	EndCity
 	TeamReveal=24,44,
 EndPlot
@@ -13043,7 +13043,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player23Culture=50
+		Player23Culture=50, (France)
 	EndCity
 	TeamReveal=23,24,44,
 EndPlot
@@ -13272,7 +13272,7 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,45,
 EndPlot
@@ -13503,7 +13503,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player24Culture=50
+		Player24Culture=50, (England)
 	EndCity
 	TeamReveal=23,24,44,
 EndPlot
@@ -13875,7 +13875,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,23,24,45,
 EndPlot
@@ -14322,7 +14322,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player24Culture=50
+		Player24Culture=50, (England)
 	EndCity
 	TeamReveal=22,23,24,44,45,
 EndPlot
@@ -14612,7 +14612,7 @@ BeginPlot
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,45,
 EndPlot
@@ -14776,7 +14776,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player24Culture=50
+		Player24Culture=50, (England)
 	EndCity
 	TeamReveal=22,23,24,44,45,
 EndPlot
@@ -15532,7 +15532,7 @@ BeginPlot
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_HARBOR
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=50
+		Player22Culture=50, (Spain)
 	EndCity
 	TeamReveal=22,45,
 EndPlot
@@ -15827,7 +15827,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player24Culture=50
+		Player24Culture=50, (England)
 	EndCity
 	TeamReveal=24,
 EndPlot
@@ -16118,7 +16118,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player23Culture=50
+		Player23Culture=50, (France)
 	EndCity
 	TeamReveal=22,23,24,29,44,45,
 EndPlot
@@ -16461,7 +16461,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player29Culture=50
+		Player29Culture=50, (Portugal)
 	EndCity
 	TeamReveal=22,29,44,
 EndPlot
@@ -16548,7 +16548,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player29Culture=50
+		Player29Culture=50, (Portugal)
 	EndCity
 	TeamReveal=22,23,29,44,45,
 EndPlot
@@ -17744,7 +17744,7 @@ BeginPlot
 		BuildingType=BUILDING_ADMINISTRATIVE_CENTER
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player29Culture=100
+		Player29Culture=100, (Portugal)
 	EndCity
 	TeamReveal=22,29,44,
 EndPlot
@@ -18204,7 +18204,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player29Culture=50
+		Player29Culture=50, (Portugal)
 	EndCity
 	TeamReveal=22,29,44,
 EndPlot
@@ -19139,7 +19139,7 @@ BeginPlot
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player29Culture=50
+		Player29Culture=50, (Portugal)
 	EndCity
 	TeamReveal=22,23,24,29,45,
 EndPlot
@@ -19669,7 +19669,7 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_LIBRARY
 		ReligionType=RELIGION_PROTESTANTISM
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
 	TeamReveal=16,44,
 EndPlot
@@ -20327,7 +20327,7 @@ BeginPlot
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player29Culture=50
+		Player29Culture=50, (Portugal)
 	EndCity
 	TeamReveal=22,24,29,38,44,45,
 EndPlot
@@ -20694,7 +20694,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player23Culture=50
+		Player23Culture=50, (France)
 	EndCity
 	TeamReveal=22,23,24,29,38,
 EndPlot
@@ -20783,7 +20783,6 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,22,23,24,29,38,45,
-	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=48,y=46
@@ -21156,7 +21155,6 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,22,23,24,29,38,44,45,
-	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=49,y=41
@@ -21236,7 +21234,7 @@ BeginPlot
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		BuildingType=BUILDING_IBERIAN_TRADING_COMPANY
 		ReligionType=RELIGION_CATHOLICISM
-		Player29Culture=250
+		Player29Culture=250, (Portugal)
 	EndCity
 	TeamReveal=16,22,23,24,29,38,45,
 EndPlot
@@ -21279,7 +21277,7 @@ BeginPlot
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=100
+		Player22Culture=100, (Spain)
 	EndCity
 	TeamReveal=16,22,23,24,29,38,45,
 EndPlot
@@ -21358,7 +21356,7 @@ BeginPlot
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player24Culture=100
+		Player24Culture=100, (England)
 	EndCity
 	TeamReveal=16,22,23,24,38,45,
 EndPlot
@@ -21679,7 +21677,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,22,23,24,29,38,45,
-	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=50,y=43
@@ -21691,7 +21688,6 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=16,22,23,24,29,38,45,
-	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=50,y=44
@@ -21700,7 +21696,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,29,38,45,
-	Player29Culture=100, (Portugal)
 EndPlot
 BeginPlot
 	x=50,y=45
@@ -22024,7 +22019,7 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_UNIVERSITY_OF_SANKORE
 		ReligionType=RELIGION_ISLAM
-		Player45Culture=100
+		Player45Culture=100, (Independent2)
 	EndCity
 	TeamReveal=38,44,45,
 EndPlot
@@ -22094,7 +22089,7 @@ BeginPlot
 		BuildingType=BUILDING_UNIVERSITY
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ISLAM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=22,24,29,35,38,44,
 EndPlot
@@ -22158,7 +22153,7 @@ BeginPlot
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		BuildingType=BUILDING_LA_MEZQUITA
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=100
+		Player22Culture=100, (Spain)
 	EndCity
 	TeamReveal=16,22,23,24,29,35,38,44,45,
 EndPlot
@@ -22678,7 +22673,7 @@ BeginPlot
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		BuildingType=BUILDING_IBERIAN_TRADING_COMPANY
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=250
+		Player22Culture=250, (Spain)
 	EndCity
 	TeamReveal=16,22,23,24,29,38,45,
 EndPlot
@@ -22817,7 +22812,7 @@ BeginPlot
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player24Culture=100
+		Player24Culture=100, (England)
 	EndCity
 	TeamReveal=16,22,23,24,38,45,
 EndPlot
@@ -23071,7 +23066,7 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_CATHEDRAL
 		ReligionType=RELIGION_ISLAM
-		Player45Culture=200
+		Player45Culture=200, (Independent2)
 	EndCity
 	TeamReveal=45,
 EndPlot
@@ -23228,7 +23223,7 @@ BeginPlot
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player23Culture=100
+		Player23Culture=100, (France)
 	EndCity
 	TeamReveal=16,22,23,24,29,38,39,44,45,
 EndPlot
@@ -23351,7 +23346,7 @@ BeginPlot
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_PROTESTANTISM
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
-		Player24Culture=250
+		Player24Culture=250, (England)
 	EndCity
 	TeamReveal=16,22,23,24,38,39,
 EndPlot
@@ -23595,7 +23590,7 @@ BeginPlot
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
 		ReligionType=RELIGION_PROTESTANTISM
-		Player38Culture=50
+		Player38Culture=50, (Netherlands)
 	EndCity
 	TeamReveal=22,24,29,38,45,
 EndPlot
@@ -23709,7 +23704,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=100
+		Player35Culture=100, (Turkey)
 	EndCity
 	TeamReveal=22,35,44,45,
 EndPlot
@@ -24206,7 +24201,7 @@ BeginPlot
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=100
+		Player22Culture=100, (Spain)
 	EndCity
 	TeamReveal=16,22,23,24,29,38,44,45,
 EndPlot
@@ -24346,7 +24341,7 @@ BeginPlot
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
 		FreeSpecialistType=SPECIALIST_GREAT_SCIENTIST
-		Player23Culture=250
+		Player23Culture=250, (Paris)
 	EndCity
 	TeamReveal=16,22,23,24,25,29,38,39,44,
 EndPlot
@@ -24641,7 +24636,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ISLAM
-		Player45Culture=100
+		Player45Culture=100, (Independent2)
 	EndCity
 	TeamReveal=38,44,45,
 EndPlot
@@ -24774,7 +24769,7 @@ BeginPlot
 		BuildingType=BUILDING_GROCER
 		BuildingType=BUILDING_COURTHOUSE
 		ReligionType=RELIGION_CATHOLICISM
-		Player23Culture=100
+		Player23Culture=100, (France)
 	EndCity
 	TeamReveal=16,22,23,24,25,29,38,39,44,45,
 EndPlot
@@ -25322,7 +25317,7 @@ BeginPlot
 		ReligionType=RELIGION_PROTESTANTISM
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
-		Player38Culture=250
+		Player38Culture=250, (Netherlands)
 	EndCity
 	TeamReveal=16,22,23,24,25,38,39,44,45,
 EndPlot
@@ -25657,7 +25652,7 @@ BeginPlot
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=100
+		Player35Culture=100, (Tanus)
 	EndCity
 	TeamReveal=25,35,44,
 EndPlot
@@ -25732,7 +25727,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,38,39,44,45,
-	Player39Culture=100, (Germany)
 EndPlot
 BeginPlot
 	x=58,y=50
@@ -25758,7 +25752,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,22,23,24,25,38,39,45,
-	Player38Culture=100, (Netherlands)
 EndPlot
 BeginPlot
 	x=58,y=53
@@ -25767,7 +25760,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,22,23,24,25,38,39,44,45,
-	Player38Culture=100, (Netherlands)
 EndPlot
 BeginPlot
 	x=58,y=54
@@ -25839,7 +25831,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_COURTHOUSE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player44Culture=100
+		Player44Culture=100, (Bergen)
 	EndCity
 	TeamReveal=16,24,39,44,
 EndPlot
@@ -26051,7 +26043,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player29Culture=50
+		Player29Culture=50, (Portugal)
 	EndCity
 	TeamReveal=22,24,29,38,
 EndPlot
@@ -26093,7 +26085,7 @@ BeginPlot
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_MARKET
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=29,44,45,
 EndPlot
@@ -26245,7 +26237,7 @@ BeginPlot
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
 		FreeSpecialistType=SPECIALIST_GREAT_ENGINEER
-		Player25Culture=100
+		Player25Culture=100, (Holy Rome)
 	EndCity
 	TeamReveal=16,22,23,24,25,38,39,44,45,
 EndPlot
@@ -26262,7 +26254,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,38,39,44,45,
-	Player39Culture=100, (Germany)
 EndPlot
 BeginPlot
 	x=59,y=50
@@ -26308,7 +26299,7 @@ BeginPlot
 		ReligionType=RELIGION_CATHOLICISM
 		ReligionType=RELIGION_PROTESTANTISM
 		HolyCityReligionType=RELIGION_PROTESTANTISM
-		Player39Culture=100
+		Player39Culture=100, (Germany)
 	EndCity
 	TeamReveal=16,22,23,24,25,38,39,45,
 EndPlot
@@ -26369,7 +26360,7 @@ BeginPlot
 		ReligionType=RELIGION_CATHOLICISM
 		ReligionType=RELIGION_PROTESTANTISM
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
-		Player39Culture=100
+		Player39Culture=100, (Germany)
 	EndCity
 	TeamReveal=16,22,23,24,25,38,39,44,45,
 EndPlot
@@ -26784,7 +26775,7 @@ BeginPlot
 		ReligionType=RELIGION_CATHOLICISM
 		HolyCityReligionType=RELIGION_CATHOLICISM
 		FreeSpecialistType=SPECIALIST_GREAT_PRIEST
-		Player45Culture=250
+		Player45Culture=250, (Independent2)
 	EndCity
 	TeamReveal=16,22,23,24,25,38,39,44,45,
 EndPlot
@@ -26827,7 +26818,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,38,39,44,45,
-	Player39Culture=100, (Germany)
 EndPlot
 BeginPlot
 	x=60,y=50
@@ -26914,7 +26904,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=16,22,23,24,25,38,39,44,45,
 EndPlot
@@ -26963,7 +26953,7 @@ BeginPlot
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=16,24,39,44,45,
 EndPlot
@@ -27279,7 +27269,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=100
+		Player35Culture=100, (Turkey)
 	EndCity
 	TeamReveal=35,44,
 EndPlot
@@ -27496,7 +27486,7 @@ BeginPlot
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=16,44,
 EndPlot
@@ -27712,7 +27702,7 @@ BeginPlot
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		ReligionType=RELIGION_CATHOLICISM
-		Player37Culture=100
+		Player37Culture=100, (Congo)
 	EndCity
 	TeamReveal=22,24,29,37,38,
 EndPlot
@@ -27889,7 +27879,7 @@ BeginPlot
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
-		Player25Culture=100
+		Player25Culture=100, (Holy Rome)
 	EndCity
 	TeamReveal=16,22,23,24,25,35,38,39,44,45,
 EndPlot
@@ -27988,7 +27978,7 @@ BeginPlot
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
-		Player25Culture=250
+		Player25Culture=250, (Holy Rome)
 	EndCity
 	TeamReveal=16,22,23,24,25,26,28,35,38,39,44,45,
 EndPlot
@@ -28008,7 +27998,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=16,22,23,24,25,26,28,38,39,45,
-	Player25Culture=100, (Holy Rome)
 EndPlot
 BeginPlot
 	x=62,y=52
@@ -28074,7 +28063,7 @@ BeginPlot
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_PROTESTANTISM
-		Player39Culture=250
+		Player39Culture=250, (Germany)
 	EndCity
 	TeamReveal=16,22,23,24,25,26,28,38,39,44,45,
 EndPlot
@@ -28256,7 +28245,7 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player38Culture=50
+		Player38Culture=50, (Netherlands)
 	EndCity
 	TeamReveal=22,24,29,38,45,
 EndPlot
@@ -28660,7 +28649,7 @@ BeginPlot
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		BuildingType=BUILDING_PROTESTANT_CATHEDRAL
 		ReligionType=RELIGION_PROTESTANTISM
-		Player16Culture=250
+		Player16Culture=250, (Vikings)
 	EndCity
 	TeamReveal=16,39,44,45,
 EndPlot
@@ -29093,7 +29082,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,23,25,26,28,38,39,44,45,
-	Player28Culture=100, (Poland)
 EndPlot
 BeginPlot
 	x=64,y=54
@@ -29514,7 +29502,7 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=100
+		Player35Culture=100, (Turkey)
 	EndCity
 	TeamReveal=25,35,44,
 EndPlot
@@ -29566,7 +29554,7 @@ BeginPlot
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
-		Player25Culture=100
+		Player25Culture=100, (Holy Rome)
 	EndCity
 	TeamReveal=16,22,23,25,26,28,35,39,44,45,
 EndPlot
@@ -29656,7 +29644,7 @@ BeginPlot
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
-		Player28Culture=250
+		Player28Culture=250, (Poland)
 	EndCity
 	TeamReveal=16,23,25,26,28,38,39,45,
 EndPlot
@@ -29689,7 +29677,7 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_COURTHOUSE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player39Culture=100
+		Player39Culture=100, (Germany)
 	EndCity
 	TeamReveal=16,25,26,28,39,45,
 EndPlot
@@ -29759,7 +29747,7 @@ BeginPlot
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player16Culture=100
+		Player16Culture=100, (Vikings)
 	EndCity
 	TeamReveal=16,44,45,
 EndPlot
@@ -30203,7 +30191,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,25,26,28,39,45,
-	Player28Culture=100, (Poland)
 EndPlot
 BeginPlot
 	x=66,y=56
@@ -30567,7 +30554,7 @@ BeginPlot
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=200
+		Player35Culture=200, (Turkey)
 	EndCity
 	TeamReveal=35,44,
 EndPlot
@@ -30617,7 +30604,7 @@ BeginPlot
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=200
+		Player35Culture=200, (Turkey)
 	EndCity
 	TeamReveal=35,44,
 EndPlot
@@ -30748,7 +30735,7 @@ BeginPlot
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
-		Player28Culture=100
+		Player28Culture=100, (Poland)
 	EndCity
 	TeamReveal=16,25,26,28,39,45,
 EndPlot
@@ -30767,14 +30754,12 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,26,28,39,
-	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=67,y=58
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,26,28,39,45,
-	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=67,y=59
@@ -30798,7 +30783,7 @@ BeginPlot
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_PROTESTANT_TEMPLE
 		ReligionType=RELIGION_PROTESTANTISM
-		Player16Culture=100
+		Player16Culture=100, (Vikings)
 	EndCity
 	TeamReveal=16,26,28,39,45,
 EndPlot
@@ -31278,7 +31263,7 @@ BeginPlot
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=300
+		Player35Culture=300, (Turkey)
 	EndCity
 	TeamReveal=25,26,35,44,
 EndPlot
@@ -31379,7 +31364,6 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=16,26,28,39,45,
-	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=68,y=59
@@ -31387,7 +31371,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,26,28,39,45,
-	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=68,y=60
@@ -31668,7 +31651,7 @@ BeginPlot
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=100
+		Player35Culture=100, (Turkey)
 	EndCity
 	TeamReveal=35,44,45,
 EndPlot
@@ -31719,7 +31702,7 @@ BeginPlot
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=200
+		Player35Culture=200, (Turkey)
 	EndCity
 	TeamReveal=35,44,
 EndPlot
@@ -31868,7 +31851,7 @@ BeginPlot
 		BuildingType=BUILDING_ORTHODOX_MONASTERY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
-		Player26Culture=100
+		Player26Culture=100, (Russia)
 	EndCity
 	TeamReveal=16,25,26,28,39,45,
 EndPlot
@@ -31891,7 +31874,6 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=16,26,28,39,45,
-	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=69,y=55
@@ -31906,7 +31888,6 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=16,26,28,39,45,
-	Player26Culture=100, (Russia)
 EndPlot
 BeginPlot
 	x=69,y=57
@@ -31947,7 +31928,7 @@ BeginPlot
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ORTHODOX_MONASTERY
 		ReligionType=RELIGION_ORTHODOXY
-		Player26Culture=100
+		Player26Culture=100, (Russia)
 	EndCity
 	TeamReveal=16,26,28,39,45,
 EndPlot
@@ -32580,7 +32561,7 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player29Culture=50
+		Player29Culture=50, (Portugal)
 	EndCity
 	TeamReveal=22,24,29,38,44,
 EndPlot
@@ -32635,7 +32616,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_COURTHOUSE
 		ReligionType=RELIGION_ISLAM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=22,24,29,38,44,
 EndPlot
@@ -32814,7 +32795,7 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=100
+		Player35Culture=100, (Turkey)
 	EndCity
 	TeamReveal=35,44,
 EndPlot
@@ -33185,7 +33166,7 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=35,44,45,
 EndPlot
@@ -33438,7 +33419,7 @@ BeginPlot
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ORTHODOX_MONASTERY
 		ReligionType=RELIGION_ORTHODOXY
-		Player26Culture=100
+		Player26Culture=100, (Russia)
 	EndCity
 	TeamReveal=16,26,
 EndPlot
@@ -33750,7 +33731,7 @@ BeginPlot
 		HolyCityReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_CATHOLICISM
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=200
+		Player35Culture=200, (Turkey)
 	EndCity
 	TeamReveal=8,35,44,
 EndPlot
@@ -33946,7 +33927,7 @@ BeginPlot
 		BuildingType=BUILDING_ST_BASILS_CATHEDRAL
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
-		Player26Culture=250
+		Player26Culture=250, (Russia)
 	EndCity
 	TeamReveal=16,26,
 EndPlot
@@ -33996,7 +33977,7 @@ BeginPlot
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ORTHODOX_MONASTERY
 		ReligionType=RELIGION_ORTHODOXY
-		Player26Culture=100
+		Player26Culture=100, (Russia)
 	EndCity
 	TeamReveal=16,26,
 EndPlot
@@ -34232,7 +34213,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_COURTHOUSE
 		ReligionType=RELIGION_ISLAM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=22,24,29,38,44,45,
 EndPlot
@@ -34360,7 +34341,7 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=100
+		Player35Culture=100, (Turkey)
 	EndCity
 	TeamReveal=8,35,44,
 EndPlot
@@ -34452,7 +34433,7 @@ BeginPlot
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ORTHODOX_MONASTERY
 		ReligionType=RELIGION_ORTHODOXY
-		Player26Culture=100
+		Player26Culture=100, (Russia)
 	EndCity
 	TeamReveal=26,35,44,45,
 EndPlot
@@ -34809,7 +34790,7 @@ BeginPlot
 		HolyCityReligionType=RELIGION_ISLAM
 		FreeSpecialistType=SPECIALIST_GREAT_PRIEST
 		FreeSpecialistType=SPECIALIST_GREAT_PRIEST
-		Player35Culture=100
+		Player35Culture=100, (Turkey)
 	EndCity
 	TeamReveal=35,44,45,
 EndPlot
@@ -34892,14 +34873,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Trabzon
 		CityPopulation=5
 		BuildingType=BUILDING_BARRACKS
@@ -34913,7 +34890,7 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_ISLAM
-		Player35Culture=100
+		Player35Culture=100, (Turkey)
 	EndCity
 	TeamReveal=8,35,44,
 EndPlot
@@ -35259,14 +35236,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Sana'a
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -35274,7 +35247,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_FORGE
 		ReligionType=RELIGION_ISLAM
-		Player45Culture=100
+		Player45Culture=100, (Independent2)
 	EndCity
 	TeamReveal=29,35,44,45,
 EndPlot
@@ -35390,13 +35363,13 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_MINE
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	TeamReveal=8,35,44,45,
+	TeamReveal=8,26,35,44,45,
 EndPlot
 BeginPlot
 	x=76,y=46
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=8,35,44,45,
+	TeamReveal=8,26,35,44,45,
 EndPlot
 BeginPlot
 	x=76,y=47
@@ -35694,7 +35667,7 @@ BeginPlot
 	x=77,y=27
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,35,38,44,
+	TeamReveal=22,24,29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=77,y=28
@@ -35791,14 +35764,10 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_OTTOMAN_JANISSARY, UnitOwner=35, (Turkey)
 	EndUnit
 	BeginCity
-		CityOwner=35
+		CityOwner=35, (Turkey)
 		CityName=Baghdad
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -35814,7 +35783,7 @@ BeginPlot
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ISLAM
 		FreeSpecialistType=SPECIALIST_GREAT_PRIEST
-		Player35Culture=150
+		Player35Culture=150, (Turkey)
 	EndCity
 	TeamReveal=8,35,44,45,
 EndPlot
@@ -35957,14 +35926,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Vyatka
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -35976,7 +35941,7 @@ BeginPlot
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ORTHODOX_MONASTERY
 		ReligionType=RELIGION_ORTHODOXY
-		Player26Culture=100
+		Player26Culture=100, (Russia)
 	EndCity
 	TeamReveal=26,
 EndPlot
@@ -36184,7 +36149,7 @@ BeginPlot
 	x=78,y=27
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,35,38,44,
+	TeamReveal=22,24,29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=78,y=28
@@ -36299,14 +36264,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
 	EndUnit
 	BeginCity
-		CityOwner=8
+		CityOwner=8, (Iran)
 		CityName=Tabriz
 		CityPopulation=7
 		BuildingType=BUILDING_BARRACKS
@@ -36320,7 +36281,7 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
 		ReligionType=RELIGION_ISLAM
-		Player8Culture=100
+		Player8Culture=100, (Iran)
 	EndCity
 	TeamReveal=8,35,44,45,
 EndPlot
@@ -36391,14 +36352,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Samara
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -36409,7 +36366,7 @@ BeginPlot
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ORTHODOX_MONASTERY
 		ReligionType=RELIGION_ORTHODOXY
-		Player26Culture=100
+		Player26Culture=100, (Russia)
 	EndCity
 	TeamReveal=26,
 EndPlot
@@ -36653,7 +36610,7 @@ BeginPlot
 	x=79,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,35,38,
+	TeamReveal=22,24,35,38,45,
 EndPlot
 BeginPlot
 	x=79,y=28
@@ -36683,13 +36640,13 @@ BeginPlot
 	x=79,y=32
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,35,38,44,
+	TeamReveal=22,24,29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=79,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=35,44,
+	TeamReveal=35,44,45,
 EndPlot
 BeginPlot
 	x=79,y=34
@@ -37064,43 +37021,43 @@ BeginPlot
 	x=80,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=35,
+	TeamReveal=35,45,
 EndPlot
 BeginPlot
 	x=80,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,29,35,
+	TeamReveal=22,29,35,45,
 EndPlot
 BeginPlot
 	x=80,y=29
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=22,29,35,38,
+	TeamReveal=22,29,35,38,45,
 EndPlot
 BeginPlot
 	x=80,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,35,38,44,
+	TeamReveal=22,24,29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=80,y=31
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,35,38,44,
+	TeamReveal=22,24,29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=80,y=32
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=22,24,29,35,38,44,
+	TeamReveal=22,24,29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=80,y=33
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=29,35,38,44,
+	TeamReveal=29,35,38,44,45,
 EndPlot
 BeginPlot
 	x=80,y=34
@@ -37167,19 +37124,19 @@ BeginPlot
 	x=80,y=43
 	TerrainType=TERRAIN_PLAINS
 	PlotType=0
-	TeamReveal=8,34,44,45,
+	TeamReveal=8,34,35,44,45,
 EndPlot
 BeginPlot
 	x=80,y=44
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=8,44,45,
+	TeamReveal=8,35,44,45,
 EndPlot
 BeginPlot
 	x=80,y=45
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,44,45,
+	TeamReveal=8,35,44,45,
 EndPlot
 BeginPlot
 	x=80,y=46
@@ -37315,14 +37272,10 @@ BeginPlot
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Obdorsk
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -37334,7 +37287,7 @@ BeginPlot
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ORTHODOX_MONASTERY
 		ReligionType=RELIGION_ORTHODOXY
-		Player26Culture=50
+		Player26Culture=50, (Russia)
 	EndCity
 	TeamReveal=26,
 EndPlot
@@ -37608,8 +37561,50 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=8, (Iran)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=8, (Iran)
+	EndUnit
 	BeginCity
-		CityOwner=8
+		CityOwner=8, (Iran)
 		CityName=Isfahan
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -37626,9 +37621,9 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_CATHEDRAL
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
 		ReligionType=RELIGION_ISLAM
-		Player8Culture=250
+		Player8Culture=250, (Iran)
 	EndCity
-	TeamReveal=8,34,44,45,
+	TeamReveal=8,34,35,44,45,
 EndPlot
 BeginPlot
 	x=81,y=42
@@ -37731,14 +37726,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Ekaterinburg
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -37750,7 +37741,7 @@ BeginPlot
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		BuildingType=BUILDING_ORTHODOX_MONASTERY
 		ReligionType=RELIGION_ORTHODOXY
-		Player26Culture=50
+		Player26Culture=50, (Russia)
 	EndCity
 	TeamReveal=26,
 EndPlot
@@ -38000,7 +37991,7 @@ BeginPlot
 	x=82,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=22,24,29,34,38,44,
 EndPlot
 BeginPlot
 	x=82,y=34
@@ -38008,28 +37999,16 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Masqat
 		CityPopulation=4
 		BuildingType=BUILDING_BARRACKS
@@ -38040,7 +38019,7 @@ BeginPlot
 		BuildingType=BUILDING_CUSTOMS_HOUSE
 		BuildingType=BUILDING_FORGE
 		ReligionType=RELIGION_ISLAM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=8,22,24,29,34,38,44,45,
 EndPlot
@@ -38070,14 +38049,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
 	EndUnit
 	BeginCity
-		CityOwner=8
+		CityOwner=8, (Iran)
 		CityName=Shiraz
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -38097,7 +38072,7 @@ BeginPlot
 		ReligionType=RELIGION_ISLAM
 		ReligionType=RELIGION_ZOROASTRIANISM
 		HolyCityReligionType=RELIGION_ZOROASTRIANISM
-		Player8Culture=100
+		Player8Culture=100, (Iran)
 	EndCity
 	TeamReveal=8,29,34,44,45,
 EndPlot
@@ -38129,7 +38104,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	TeamReveal=8,34,44,45,
+	TeamReveal=8,34,35,44,45,
 EndPlot
 BeginPlot
 	x=82,y=43
@@ -38556,28 +38531,16 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_CUIRASSIER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Merv
 		CityPopulation=4
 		BuildingType=BUILDING_STABLE
@@ -38587,7 +38550,7 @@ BeginPlot
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ISLAM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=8,44,45,
 EndPlot
@@ -38631,6 +38594,7 @@ BeginPlot
 	x=83,y=51
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	TeamReveal=26,
 EndPlot
 BeginPlot
 	x=83,y=52
@@ -38919,31 +38883,31 @@ BeginPlot
 	x=84,y=32
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,38,44,
+	TeamReveal=5,24,29,38,44,
 EndPlot
 BeginPlot
 	x=84,y=33
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,
+	TeamReveal=5,22,24,29,34,38,44,
 EndPlot
 BeginPlot
 	x=84,y=34
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=8,22,24,29,34,38,44,
+	TeamReveal=5,8,22,24,29,34,38,44,
 EndPlot
 BeginPlot
 	x=84,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=8,22,24,29,34,38,44,45,
+	TeamReveal=5,8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=84,y=36
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,22,24,29,34,38,44,45,
+	TeamReveal=5,8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=84,y=37
@@ -38953,8 +38917,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=84,y=38
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_SPICES
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	TeamReveal=8,24,34,44,45,
@@ -38977,14 +38941,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_IRANIAN_QIZILBASH, UnitOwner=8, (Iran)
 	EndUnit
 	BeginCity
-		CityOwner=8
+		CityOwner=8, (Iran)
 		CityName=Herat
 		CityPopulation=5
 		BuildingType=BUILDING_BARRACKS
@@ -38998,7 +38958,7 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
 		ReligionType=RELIGION_ISLAM
-		Player8Culture=100
+		Player8Culture=100, (Iran)
 	EndCity
 	TeamReveal=8,34,44,45,
 EndPlot
@@ -39129,14 +39089,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Tyumen
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -39145,7 +39101,7 @@ BeginPlot
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		ReligionType=RELIGION_ORTHODOXY
-		Player26Culture=50
+		Player26Culture=50, (Russia)
 	EndCity
 	TeamReveal=26,
 EndPlot
@@ -39378,61 +39334,54 @@ BeginPlot
 	x=85,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,44,
+	TeamReveal=5,29,44,
 EndPlot
 BeginPlot
 	x=85,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,44,
+	TeamReveal=5,29,44,
 EndPlot
 BeginPlot
 	x=85,y=32
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,44,
+	TeamReveal=5,24,29,44,
 EndPlot
 BeginPlot
 	x=85,y=33
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,34,44,
+	TeamReveal=5,24,29,34,44,
 EndPlot
 BeginPlot
 	x=85,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=8,24,29,34,38,44,
+	TeamReveal=5,8,24,29,34,38,44,
 EndPlot
 BeginPlot
 	x=85,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=8,22,24,29,34,38,44,45,
+	TeamReveal=5,8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=85,y=36
 	RiverNSDirection=2
 	isWOfRiver
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
 	EndUnit
 	BeginCity
-		CityOwner=34
+		CityOwner=34, (Mughals)
 		CityName=Kolachi
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -39443,9 +39392,9 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
 		ReligionType=RELIGION_ISLAM
-		Player34Culture=50
+		Player34Culture=50, (Mughals)
 	EndCity
-	TeamReveal=8,22,24,29,34,38,44,45,
+	TeamReveal=5,8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=85,y=37
@@ -39528,28 +39477,16 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_CUIRASSIER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Samarkand
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
@@ -39561,7 +39498,7 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_CATHEDRAL
 		ReligionType=RELIGION_ISLAM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=8,44,
 EndPlot
@@ -39847,58 +39784,58 @@ BeginPlot
 	x=86,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=10,29,
 EndPlot
 BeginPlot
 	x=86,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,
+	TeamReveal=5,10,29,
 EndPlot
 BeginPlot
 	x=86,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,44,
+	TeamReveal=5,10,29,44,
 EndPlot
 BeginPlot
 	x=86,y=32
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,44,45,
+	TeamReveal=5,10,24,29,44,45,
 EndPlot
 BeginPlot
 	x=86,y=33
 	BonusType=BONUS_OIL
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,10,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=86,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=86,y=35
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=8,22,24,29,34,38,44,45,
+	TeamReveal=5,8,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=86,y=36
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=8,22,24,34,38,44,45,
+	TeamReveal=5,8,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=86,y=37
-	RouteType=ROUTE_ROAD
 	ImprovementType=IMPROVEMENT_HAMLET
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	TeamReveal=8,22,24,34,38,44,45,
@@ -39919,8 +39856,8 @@ BeginPlot
 	x=86,y=39
 	RiverNSDirection=2
 	isWOfRiver
-	ImprovementType=IMPROVEMENT_QUARRY
 	BonusType=BONUS_MARBLE
+	ImprovementType=IMPROVEMENT_QUARRY
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=8,24,34,44,45,
@@ -40254,74 +40191,75 @@ BeginPlot
 	x=87,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
+	TeamReveal=10,
 EndPlot
 BeginPlot
 	x=87,y=28
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,44,
+	TeamReveal=10,29,44,
 EndPlot
 BeginPlot
 	x=87,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,44,
+	TeamReveal=10,29,44,
 EndPlot
 BeginPlot
 	x=87,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,34,44,45,
+	TeamReveal=5,10,29,34,44,45,
 EndPlot
 BeginPlot
 	x=87,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,34,44,45,
+	TeamReveal=5,10,29,34,44,45,
 EndPlot
 BeginPlot
 	x=87,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=24,29,34,44,45,
+	TeamReveal=5,10,24,29,34,44,45,
 EndPlot
 BeginPlot
 	x=87,y=33
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=34
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=36
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_COTTON
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=8,22,24,34,38,44,45,
+	TeamReveal=5,8,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=37
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,22,24,34,38,44,45,
+	TeamReveal=5,8,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=87,y=38
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=87,y=39
@@ -40338,14 +40276,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
 	EndUnit
 	BeginCity
-		CityOwner=34
+		CityOwner=34, (Mughals)
 		CityName=Lahore
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -40359,7 +40293,7 @@ BeginPlot
 		BuildingType=BUILDING_HARMANDIR_SAHIB
 		ReligionType=RELIGION_ISLAM
 		ReligionType=RELIGION_BUDDHISM
-		Player34Culture=100
+		Player34Culture=100, (Mughals)
 	EndCity
 	TeamReveal=8,34,44,45,
 EndPlot
@@ -40691,55 +40625,104 @@ BeginPlot
 	x=88,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=44,
+	TeamReveal=10,44,
 EndPlot
 BeginPlot
 	x=88,y=28
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,38,44,
+	TeamReveal=10,29,38,44,
 EndPlot
 BeginPlot
 	x=88,y=29
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=29,38,44,
+	TeamReveal=10,29,38,44,
 EndPlot
 BeginPlot
 	x=88,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=31
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_FISH
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=33
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_BANANA
+	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=34
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CUIRASSIER, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=5, (India)
+	EndUnit
 	BeginCity
-		CityOwner=5
+		CityOwner=5, (India)
 		CityName=Mumbai
 		CityPopulation=6
 		BuildingType=BUILDING_PALACE
@@ -40747,16 +40730,17 @@ BeginPlot
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_HARBOR
+		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_THEATRE
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_HINDU_TEMPLE
 		BuildingType=BUILDING_HINDU_MONASTERY
 		ReligionType=RELIGION_HINDUISM
-		Player5Culture=75
+		FreeSpecialistType=SPECIALIST_GREAT_GENERAL
+		Player5Culture=75, (India)
 	EndCity
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=35
@@ -40765,7 +40749,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=36
@@ -40773,22 +40757,22 @@ BeginPlot
 	RiverWEDirection=3
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=22,24,34,38,44,45,
+	TeamReveal=5,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=37
-	RouteType=ROUTE_ROAD
-	ImprovementType=IMPROVEMENT_PASTURE
 	BonusType=BONUS_HORSE
+	ImprovementType=IMPROVEMENT_PASTURE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=22,24,34,38,44,45,
+	TeamReveal=5,22,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=88,y=38
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=88,y=39
@@ -40796,7 +40780,7 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=88,y=40
@@ -40806,16 +40790,16 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=88,y=41
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_SUGAR
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=8,34,44,45,
 EndPlot
 BeginPlot
 	x=88,y=42
-	ImprovementType=IMPROVEMENT_FARM
 	BonusType=BONUS_WHEAT
+	ImprovementType=IMPROVEMENT_FARM
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=8,34,44,45,
@@ -41136,65 +41120,65 @@ BeginPlot
 	x=89,y=27
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=38,44,
+	TeamReveal=10,38,44,
 EndPlot
 BeginPlot
 	x=89,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,29,38,44,
+	TeamReveal=10,22,29,38,44,
 EndPlot
 BeginPlot
 	x=89,y=29
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_PEARL
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=89,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=31
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=32
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=33
-	RouteType=ROUTE_ROAD
-	ImprovementType=IMPROVEMENT_MINE
 	BonusType=BONUS_GEMS
+	ImprovementType=IMPROVEMENT_MINE
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=34
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=35
-	RouteType=ROUTE_ROAD
 	isNOfRiver
 	RiverWEDirection=3
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=36
@@ -41205,31 +41189,31 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=89,y=37
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=89,y=38
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=89,y=39
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=89,y=40
-	ImprovementType=IMPROVEMENT_PASTURE
 	BonusType=BONUS_COW
+	ImprovementType=IMPROVEMENT_PASTURE
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=8,34,44,
@@ -41254,6 +41238,7 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	TeamReveal=34,44,
 EndPlot
 BeginPlot
 	x=89,y=44
@@ -41281,21 +41266,13 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Kashgar
 		CityPopulation=4
 		BuildingType=BUILDING_WALLS
@@ -41305,7 +41282,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ISLAM
-		Player44Culture=200
+		Player44Culture=200, (Independent)
 	EndCity
 	TeamReveal=1,44,
 EndPlot
@@ -41391,14 +41368,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=26
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=26, (Russia)
 	EndUnit
 	BeginCity
-		CityOwner=26
+		CityOwner=26, (Russia)
 		CityName=Tomsk
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -41408,7 +41381,7 @@ BeginPlot
 		BuildingType=BUILDING_COURTHOUSE
 		BuildingType=BUILDING_ORTHODOX_TEMPLE
 		ReligionType=RELIGION_ORTHODOXY
-		Player26Culture=50
+		Player26Culture=50, (Russia)
 	EndCity
 	TeamReveal=26,
 EndPlot
@@ -41613,119 +41586,142 @@ BeginPlot
 	x=90,y=27
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=38,44,
+	TeamReveal=10,38,44,
 EndPlot
 BeginPlot
 	x=90,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=90,y=29
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=90,y=30
 	RiverNSDirection=2
 	isWOfRiver
-	ImprovementType=IMPROVEMENT_MINE
 	BonusType=BONUS_GOLD
+	ImprovementType=IMPROVEMENT_MINE
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=31
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=10, (Tamils)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=10, (Tamils)
+	EndUnit
 	BeginCity
-		CityOwner=10
+		CityOwner=10, (Tamils)
 		CityName=Mahishuru
 		CityPopulation=5
 		BuildingType=BUILDING_PALACE
-		BuildingType=BUILDING_BARRACKS
-		BuildingType=BUILDING_TAMIL_SANGAM
 		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_FORGE
+		BuildingType=BUILDING_TAMIL_SANGAM
 		BuildingType=BUILDING_HINDU_TEMPLE
 		BuildingType=BUILDING_HINDU_MONASTERY
-		ReligionType=RELIGION_HINDUISM
 		ReligionType=RELIGION_ISLAM
-		Player10Culture=50
+		ReligionType=RELIGION_HINDUISM
+		Player10Culture=50, (Tamils)
 	EndCity
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=32
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=33
 	isNOfRiver
 	RiverWEDirection=1
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_SUGAR
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,10,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=34
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,10,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=35
-	ImprovementType=IMPROVEMENT_FARM
 	BonusType=BONUS_RICE
+	ImprovementType=IMPROVEMENT_FARM
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=36
-	RouteType=ROUTE_ROAD
 	BonusType=BONUS_COTTON
 	ImprovementType=IMPROVEMENT_PLANTATION
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=90,y=37
 	isNOfRiver
 	RiverWEDirection=3
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=5
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=5, (India)
 	EndUnit
 	BeginCity
-		CityOwner=5
+		CityOwner=5, (India)
 		CityName=Bhopal
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -41734,34 +41730,61 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player5Culture=75
+		Player5Culture=75, (India)
 	EndCity
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=90,y=38
-	RouteType=ROUTE_ROAD
 	BonusType=BONUS_WHEAT
 	ImprovementType=IMPROVEMENT_FARM
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=90,y=39
-	ImprovementType=IMPROVEMENT_CAMP
 	BonusType=BONUS_IVORY
+	ImprovementType=IMPROVEMENT_CAMP
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=90,y=40
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUGHAL_SIEGE_ELEPHANT, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUGHAL_SIEGE_ELEPHANT, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_PIKEMAN, UnitOwner=34, (Mughals)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_PIKEMAN, UnitOwner=34, (Mughals)
+	EndUnit
 	BeginCity
-		CityOwner=34
+		CityOwner=34, (Mughals)
 		CityName=Delhi
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -41775,13 +41798,13 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		BuildingType=BUILDING_ISLAMIC_CATHEDRAL
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
-		BuildingType=BUILDING_TAJ_MAHAL
 		BuildingType=BUILDING_RED_FORT
+		BuildingType=BUILDING_TAJ_MAHAL
 		ReligionType=RELIGION_ISLAM
 		ReligionType=RELIGION_HINDUISM
-		Player34Culture=250
+		Player34Culture=250, (Mughals)
 	EndCity
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=90,y=41
@@ -42112,22 +42135,22 @@ BeginPlot
 	x=91,y=27
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=29,38,44,
+	TeamReveal=10,29,38,44,
 EndPlot
 BeginPlot
 	x=91,y=28
-	ImprovementType=IMPROVEMENT_PASTURE
 	BonusType=BONUS_COW
+	ImprovementType=IMPROVEMENT_PASTURE
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=91,y=29
 	BonusType=BONUS_ALUMINUM
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=91,y=30
@@ -42136,63 +42159,52 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=31
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=32
-	RouteType=ROUTE_ROAD
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=33
 	isNOfRiver
 	RiverWEDirection=1
-	ImprovementType=IMPROVEMENT_CAMP
 	BonusType=BONUS_IVORY
+	ImprovementType=IMPROVEMENT_CAMP
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=34
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Hyderabad
 		CityPopulation=7
 		BuildingType=BUILDING_WALLS
@@ -42205,9 +42217,9 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_MONASTERY
 		ReligionType=RELIGION_ISLAM
 		ReligionType=RELIGION_HINDUISM
-		Player45Culture=200
+		Player45Culture=200, (Independent2)
 	EndCity
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,10,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=35
@@ -42219,7 +42231,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=36
@@ -42227,7 +42239,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=91,y=37
@@ -42237,14 +42249,14 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_MINE
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=91,y=38
 	FeatureType=FEATURE_JUNGLE, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=91,y=39
@@ -42253,18 +42265,18 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=91,y=40
 	RiverNSDirection=2
 	isWOfRiver
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_DYE
+	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=8,24,34,44,45,
+	TeamReveal=5,8,24,34,44,45,
 EndPlot
 BeginPlot
 	x=91,y=41
@@ -42297,8 +42309,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=91,y=45
-	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_VILLAGE
+	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	TeamReveal=1,44,
@@ -42598,85 +42610,62 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=92,y=27
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_PEARL
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=92,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=92,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=92,y=30
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=31
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=32
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Madras
 		CityPopulation=5
 		BuildingType=BUILDING_WALLS
@@ -42689,9 +42678,9 @@ BeginPlot
 		BuildingType=BUILDING_HINDU_MONASTERY
 		ReligionType=RELIGION_PROTESTANTISM
 		ReligionType=RELIGION_HINDUISM
-		Player24Culture=50
+		Player24Culture=50, (England)
 	EndCity
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=33
@@ -42700,7 +42689,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=34
@@ -42709,7 +42698,7 @@ BeginPlot
 	ImprovementType=IMPROVEMENT_HAMLET
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=35
@@ -42719,14 +42708,14 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=36
 	FeatureType=FEATURE_JUNGLE, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=92,y=37
@@ -42735,7 +42724,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=38
@@ -42745,14 +42734,14 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=39
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=40
@@ -42762,14 +42751,14 @@ BeginPlot
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=41
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,24,34,44,45,
+	TeamReveal=1,5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=92,y=42
@@ -43083,27 +43072,23 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=93,y=27
-	ImprovementType=IMPROVEMENT_MINE
 	BonusType=BONUS_IRON
+	ImprovementType=IMPROVEMENT_MINE
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=93,y=28
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Colombo
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -43116,41 +43101,41 @@ BeginPlot
 		ReligionType=RELIGION_PROTESTANTISM
 		ReligionType=RELIGION_HINDUISM
 		ReligionType=RELIGION_BUDDHISM
-		Player38Culture=50
+		Player38Culture=50, (Netherlands)
 	EndCity
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=93,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=93,y=30
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=31
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=33
-	ImprovementType=IMPROVEMENT_PASTURE
 	BonusType=BONUS_COW
+	ImprovementType=IMPROVEMENT_PASTURE
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=34
@@ -43158,7 +43143,7 @@ BeginPlot
 	RiverWEDirection=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=5,10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=35
@@ -43166,7 +43151,7 @@ BeginPlot
 	FeatureType=FEATURE_JUNGLE, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=5,10,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=36
@@ -43174,7 +43159,7 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=37
@@ -43183,7 +43168,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,38,45,
+	TeamReveal=5,24,34,38,45,
 EndPlot
 BeginPlot
 	x=93,y=38
@@ -43192,13 +43177,13 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	TeamReveal=24,34,38,44,45,
+	TeamReveal=5,24,34,38,44,45,
 EndPlot
 BeginPlot
 	x=93,y=39
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=93,y=40
@@ -43208,13 +43193,13 @@ BeginPlot
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=93,y=41
 	TerrainType=TERRAIN_GRASS
 	PlotType=0
-	TeamReveal=1,24,34,44,45,
+	TeamReveal=1,5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=93,y=42
@@ -43257,8 +43242,8 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	ImprovementType=IMPROVEMENT_VILLAGE
-	RouteType=ROUTE_ROAD
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	TeamReveal=1,44,
@@ -43524,8 +43509,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=94,y=27
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_FISH
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 	TeamReveal=22,24,29,38,
@@ -43534,39 +43519,39 @@ BeginPlot
 	x=94,y=28
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=10,22,24,29,38,
 EndPlot
 BeginPlot
 	x=94,y=29
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,
+	TeamReveal=10,22,24,29,38,
 EndPlot
 BeginPlot
 	x=94,y=30
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,29,38,44,
+	TeamReveal=10,22,24,29,38,44,
 EndPlot
 BeginPlot
 	x=94,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,29,34,38,44,45,
+	TeamReveal=10,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=94,y=32
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=94,y=33
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_FISH
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,34,38,44,45,
+	TeamReveal=10,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=94,y=34
@@ -43584,8 +43569,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=94,y=36
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_TEA
+	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -43595,8 +43580,8 @@ BeginPlot
 	x=94,y=37
 	isNOfRiver
 	RiverWEDirection=1
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_COTTON
+	ImprovementType=IMPROVEMENT_PLANTATION
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	TeamReveal=22,24,29,34,38,44,45,
@@ -43611,11 +43596,11 @@ EndPlot
 BeginPlot
 	x=94,y=39
 	BonusType=BONUS_DYE
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=94,y=40
@@ -43625,21 +43610,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=34
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=34, (Mughals)
 	EndUnit
 	BeginCity
-		CityOwner=34
+		CityOwner=34, (Mughals)
 		CityName=Azimabad
 		CityPopulation=10
 		BuildingType=BUILDING_STABLE
@@ -43660,9 +43637,9 @@ BeginPlot
 		HolyCityReligionType=RELIGION_BUDDHISM
 		FreeSpecialistType=SPECIALIST_GREAT_PRIEST
 		FreeSpecialistType=SPECIALIST_GREAT_PRIEST
-		Player34Culture=200
+		Player34Culture=200, (Mughals)
 	EndCity
-	TeamReveal=24,34,44,45,
+	TeamReveal=5,24,34,44,45,
 EndPlot
 BeginPlot
 	x=94,y=41
@@ -43714,21 +43691,13 @@ BeginPlot
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CUIRASSIER, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_CUIRASSIER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Turfan
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -43737,7 +43706,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ISLAM
-		Player44Culture=200
+		Player44Culture=200, (Independent)
 	EndCity
 	TeamReveal=1,44,
 EndPlot
@@ -44018,13 +43987,13 @@ BeginPlot
 	x=95,y=31
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=24,38,44,
+	TeamReveal=24,38,44,45,
 EndPlot
 BeginPlot
 	x=95,y=32
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,38,44,
+	TeamReveal=22,24,38,44,45,
 EndPlot
 BeginPlot
 	x=95,y=33
@@ -44042,90 +44011,51 @@ BeginPlot
 	x=95,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=95,y=36
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=95,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_ENGLISH_REDCOAT, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CANNON, UnitOwner=24
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK_CITY
+		UnitType=UNIT_CANNON, UnitOwner=24, (England)
 	EndUnit
 	BeginCity
-		CityOwner=24
+		CityOwner=24, (England)
 		CityName=Calcutta
 		CityPopulation=6
 		BuildingType=BUILDING_WALLS
@@ -44138,7 +44068,7 @@ BeginPlot
 		BuildingType=BUILDING_HINDU_MONASTERY
 		ReligionType=RELIGION_PROTESTANTISM
 		ReligionType=RELIGION_HINDUISM
-		Player24Culture=50
+		Player24Culture=50, (England)
 	EndCity
 	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
@@ -44155,8 +44085,8 @@ BeginPlot
 	x=95,y=39
 	RiverNSDirection=2
 	isWOfRiver
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_BANANA
+	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -44166,8 +44096,8 @@ BeginPlot
 	x=95,y=40
 	isNOfRiver
 	RiverWEDirection=1
-	ImprovementType=IMPROVEMENT_PLANTATION
 	BonusType=BONUS_TEA
+	ImprovementType=IMPROVEMENT_PLANTATION
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -44529,14 +44459,14 @@ BeginPlot
 	x=96,y=35
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
-	TeamReveal=22,24,29,36,38,44,45,
+	TeamReveal=22,24,29,34,36,38,44,45,
 EndPlot
 BeginPlot
 	x=96,y=36
-	TerrainType=TERRAIN_COAST
 	BonusType=BONUS_FISH
+	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,24,29,38,44,45,
+	TeamReveal=22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=96,y=37
@@ -44597,14 +44527,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (China)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (China)
 		CityName=Lasa
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -44615,7 +44541,7 @@ BeginPlot
 		ReligionType=RELIGION_BUDDHISM
 		FreeSpecialistType=SPECIALIST_GREAT_PRIEST
 		FreeSpecialistType=SPECIALIST_GREAT_PRIEST
-		Player44Culture=100
+		Player44Culture=100, (China)
 	EndCity
 	TeamReveal=1,34,44,45,
 EndPlot
@@ -44639,8 +44565,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=96,y=47
-	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_VILLAGE
+	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	TeamReveal=1,44,
@@ -44959,13 +44885,13 @@ BeginPlot
 	x=97,y=35
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=1,22,24,29,36,38,44,45,
+	TeamReveal=1,22,24,29,34,36,38,44,45,
 EndPlot
 BeginPlot
 	x=97,y=36
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=1,22,24,29,38,44,45,
+	TeamReveal=1,22,24,29,34,38,44,45,
 EndPlot
 BeginPlot
 	x=97,y=37
@@ -45368,28 +45294,16 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Yangon
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -45403,9 +45317,9 @@ BeginPlot
 		BuildingType=BUILDING_BUDDHIST_MONASTERY
 		BuildingType=BUILDING_SHWEDAGON_PAYA
 		ReligionType=RELIGION_BUDDHISM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
-	TeamReveal=1,22,24,29,36,38,44,45,
+	TeamReveal=1,22,24,29,34,36,38,44,45,
 EndPlot
 BeginPlot
 	x=98,y=37
@@ -45434,14 +45348,14 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=1,34,44,45,
+	TeamReveal=1,24,34,44,45,
 EndPlot
 BeginPlot
 	x=98,y=40
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,34,44,45,
+	TeamReveal=1,24,34,44,45,
 EndPlot
 BeginPlot
 	x=98,y=41
@@ -45776,8 +45690,8 @@ EndPlot
 BeginPlot
 	x=99,y=28
 	BonusType=BONUS_SUGAR
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -45830,8 +45744,8 @@ EndPlot
 BeginPlot
 	x=99,y=36
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -45840,8 +45754,8 @@ EndPlot
 BeginPlot
 	x=99,y=37
 	BonusType=BONUS_TEA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -45863,7 +45777,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,34,44,45,
+	TeamReveal=1,24,34,44,45,
 EndPlot
 BeginPlot
 	x=99,y=40
@@ -45872,7 +45786,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,34,44,45,
+	TeamReveal=1,24,34,44,45,
 EndPlot
 BeginPlot
 	x=99,y=41
@@ -45882,14 +45796,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Chengdu
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -45898,7 +45808,7 @@ BeginPlot
 		BuildingType=BUILDING_CHINESE_TAIXUE
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		ReligionType=RELIGION_CONFUCIANISM
-		Player1Culture=100
+		Player1Culture=100, (China)
 	EndCity
 	TeamReveal=1,44,45,
 EndPlot
@@ -46217,28 +46127,16 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=45
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Palembang
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -46249,14 +46147,14 @@ BeginPlot
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ISLAM
-		Player45Culture=100
+		Player45Culture=100, (Independent2)
 	EndCity
 	TeamReveal=38,44,45,
 EndPlot
 BeginPlot
 	x=100,y=27
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_VILLAGE
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=29,38,44,45,
@@ -46276,8 +46174,8 @@ EndPlot
 BeginPlot
 	x=100,y=30
 	BonusType=BONUS_SUGAR
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -46286,8 +46184,8 @@ EndPlot
 BeginPlot
 	x=100,y=31
 	BonusType=BONUS_DYE
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -46296,8 +46194,8 @@ EndPlot
 BeginPlot
 	x=100,y=32
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -46308,8 +46206,8 @@ BeginPlot
 	RiverNSDirection=2
 	isWOfRiver
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -46405,14 +46303,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Xi'an
 		CityPopulation=8
 		BuildingType=BUILDING_BARRACKS
@@ -46430,7 +46324,7 @@ BeginPlot
 		BuildingType=BUILDING_TERRACOTTA_ARMY
 		ReligionType=RELIGION_CONFUCIANISM
 		ReligionType=RELIGION_TAOISM
-		Player1Culture=300
+		Player1Culture=300, (China)
 	EndCity
 	TeamReveal=1,44,45,
 EndPlot
@@ -46745,21 +46639,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Malakka
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -46774,7 +46660,7 @@ BeginPlot
 		ReligionType=RELIGION_ISLAM
 		ReligionType=RELIGION_BUDDHISM
 		ReligionType=RELIGION_CONFUCIANISM
-		Player38Culture=50
+		Player38Culture=50, (Netherlands)
 	EndCity
 	TeamReveal=1,22,29,36,38,44,45,
 EndPlot
@@ -46802,8 +46688,44 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_THAI_CHANG_SUEK, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_THAI_CHANG_SUEK, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_THAI_CHANG_SUEK, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_THAI_CHANG_SUEK, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_PIKEMAN, UnitOwner=36, (Thailand)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_PIKEMAN, UnitOwner=36, (Thailand)
+	EndUnit
 	BeginCity
-		CityOwner=36
+		CityOwner=36, (Thailand)
 		CityName=Ayutthaya
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -46822,7 +46744,7 @@ BeginPlot
 		BuildingType=BUILDING_WAT_PREAH_PISNULOK
 		ReligionType=RELIGION_BUDDHISM
 		FreeSpecialistType=SPECIALIST_GREAT_PRIEST
-		Player36Culture=250
+		Player36Culture=250, (Thailand)
 	EndCity
 	TeamReveal=1,22,29,36,38,44,
 EndPlot
@@ -46862,35 +46784,19 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Hanoi
 		CityPopulation=7
 		BuildingType=BUILDING_GRANARY
@@ -46904,15 +46810,15 @@ BeginPlot
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		ReligionType=RELIGION_BUDDHISM
 		ReligionType=RELIGION_CONFUCIANISM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=1,22,29,36,38,44,45,
 EndPlot
 BeginPlot
 	x=101,y=38
 	BonusType=BONUS_TEA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -47347,8 +47253,8 @@ EndPlot
 BeginPlot
 	x=102,y=38
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -47377,14 +47283,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Chongqing
 		CityPopulation=7
 		BuildingType=BUILDING_GRANARY
@@ -47393,7 +47295,7 @@ BeginPlot
 		BuildingType=BUILDING_CHINESE_TAIXUE
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		ReligionType=RELIGION_CONFUCIANISM
-		Player1Culture=100
+		Player1Culture=100, (China)
 	EndCity
 	TeamReveal=1,44,45,
 EndPlot
@@ -47450,12 +47352,62 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=1, (China)
+	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Beijing
 		CityPopulation=9
 		BuildingType=BUILDING_PALACE
-		BuildingType=BUILDING_FORBIDDEN_PALACE
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
@@ -47467,9 +47419,10 @@ BeginPlot
 		BuildingType=BUILDING_CONFUCIAN_MONASTERY
 		BuildingType=BUILDING_TAOIST_TEMPLE
 		BuildingType=BUILDING_GREAT_WALL
+		BuildingType=BUILDING_FORBIDDEN_PALACE
 		ReligionType=RELIGION_CONFUCIANISM
 		ReligionType=RELIGION_TAOISM
-		Player1Culture=150
+		Player1Culture=150, (China)
 	EndCity
 	TeamReveal=1,45,
 EndPlot
@@ -47789,7 +47742,7 @@ BeginPlot
 	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	TeamReveal=1,22,29,36,38,
+	TeamReveal=1,22,29,36,38,44,
 EndPlot
 BeginPlot
 	x=103,y=34
@@ -47803,8 +47756,8 @@ EndPlot
 BeginPlot
 	x=103,y=35
 	BonusType=BONUS_DYE
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	TeamReveal=1,22,29,36,38,44,45,
@@ -47826,8 +47779,8 @@ EndPlot
 BeginPlot
 	x=103,y=38
 	BonusType=BONUS_SILK
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -47880,14 +47833,10 @@ BeginPlot
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Kaifeng
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -47907,7 +47856,7 @@ BeginPlot
 		HolyCityReligionType=RELIGION_CONFUCIANISM
 		ReligionType=RELIGION_TAOISM
 		HolyCityReligionType=RELIGION_TAOISM
-		Player1Culture=100
+		Player1Culture=100, (China)
 	EndCity
 	TeamReveal=1,45,
 EndPlot
@@ -47985,13 +47934,14 @@ BeginPlot
 	x=103,y=54
 	TerrainType=TERRAIN_GRASS
 	PlotType=0
-	TeamReveal=1,
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=103,y=55
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=103,y=56
@@ -48208,35 +48158,19 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_DUTCH_EAST_INDIAMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Batavia
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -48249,7 +48183,7 @@ BeginPlot
 		ReligionType=RELIGION_PROTESTANTISM
 		ReligionType=RELIGION_ISLAM
 		ReligionType=RELIGION_BUDDHISM
-		Player38Culture=50
+		Player38Culture=50, (Netherlands)
 	EndCity
 	TeamReveal=38,44,45,
 EndPlot
@@ -48262,8 +48196,8 @@ EndPlot
 BeginPlot
 	x=104,y=27
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -48273,33 +48207,20 @@ BeginPlot
 	x=104,y=28
 	isNOfRiver
 	RiverWEDirection=3
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Pontianak
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -48312,7 +48233,7 @@ BeginPlot
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_HINDUISM
 		ReligionType=RELIGION_BUDDHISM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=36,38,44,45,
 EndPlot
@@ -48342,31 +48263,20 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=104,y=33
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Saigon
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
@@ -48380,9 +48290,9 @@ BeginPlot
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		ReligionType=RELIGION_BUDDHISM
 		ReligionType=RELIGION_CONFUCIANISM
-		Player44Culture=50
+		Player44Culture=50, (Independent)
 	EndCity
-	TeamReveal=1,22,29,36,38,
+	TeamReveal=1,22,29,36,38,44,
 EndPlot
 BeginPlot
 	x=104,y=34
@@ -48552,7 +48462,7 @@ BeginPlot
 	x=104,y=55
 	TerrainType=TERRAIN_GRASS
 	PlotType=0
-	TeamReveal=1,
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=104,y=56
@@ -48779,8 +48689,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=105,y=27
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_VILLAGE
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -48822,11 +48732,11 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=105,y=33
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	BonusType=BONUS_CLAM
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=22,29,36,
+	TeamReveal=22,29,36,44,
 EndPlot
 BeginPlot
 	x=105,y=34
@@ -48864,18 +48774,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Guangzhou
 		CityPopulation=10
 		BuildingType=BUILDING_GRANARY
-		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_LIGHTHOUSE
 		BuildingType=BUILDING_HARBOR
@@ -48885,15 +48790,15 @@ BeginPlot
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		ReligionType=RELIGION_BUDDHISM
 		ReligionType=RELIGION_CONFUCIANISM
-		Player1Culture=100
+		Player1Culture=100, (China)
 	EndCity
 	TeamReveal=1,22,29,44,45,
 EndPlot
 BeginPlot
 	x=105,y=40
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=1,22,29,45,
@@ -48966,27 +48871,19 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Shenyang
 		CityPopulation=6
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
-		Player1Culture=80
+		Player1Culture=80, (China)
 	EndCity
 	TeamReveal=1,12,44,45,
 EndPlot
@@ -49035,6 +48932,7 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=105,y=56
@@ -49244,8 +49142,8 @@ EndPlot
 BeginPlot
 	x=106,y=25
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -49329,7 +49227,7 @@ BeginPlot
 	x=106,y=37
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=1,22,29,45,
+	TeamReveal=1,22,29,44,45,
 EndPlot
 BeginPlot
 	x=106,y=38
@@ -49387,14 +49285,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Shanghai
 		CityPopulation=10
 		BuildingType=BUILDING_GRANARY
@@ -49411,7 +49305,7 @@ BeginPlot
 		BuildingType=BUILDING_PORCELAIN_TOWER
 		ReligionType=RELIGION_CONFUCIANISM
 		ReligionType=RELIGION_TAOISM
-		Player1Culture=100
+		Player1Culture=100, (China)
 	EndCity
 	TeamReveal=1,12,15,44,45,
 EndPlot
@@ -49460,8 +49354,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=106,y=51
-	RouteType=ROUTE_ROAD
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=1,12,44,45,
@@ -49487,19 +49381,21 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=1,
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=106,y=55
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=106,y=56
 	FeatureType=FEATURE_FOREST, FeatureVariety=2
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=106,y=57
@@ -49696,8 +49592,8 @@ EndPlot
 BeginPlot
 	x=107,y=24
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -49779,7 +49675,7 @@ BeginPlot
 	x=107,y=37
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	TeamReveal=1,15,22,29,45,
+	TeamReveal=1,15,22,29,44,45,
 EndPlot
 BeginPlot
 	x=107,y=38
@@ -49814,14 +49710,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=1
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=1, (China)
 	EndUnit
 	BeginCity
-		CityOwner=1
+		CityOwner=1, (China)
 		CityName=Hangzhou
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -49834,7 +49726,7 @@ BeginPlot
 		BuildingType=BUILDING_CONFUCIAN_MONASTERY
 		ReligionType=RELIGION_BUDDHISM
 		ReligionType=RELIGION_CONFUCIANISM
-		Player1Culture=100
+		Player1Culture=100, (China)
 	EndCity
 	TeamReveal=1,12,15,44,45,
 EndPlot
@@ -49906,26 +49798,23 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=107,y=52
-	RouteType=ROUTE_ROAD
 	BonusType=BONUS_OIL
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=1,12,44,
 EndPlot
 BeginPlot
 	x=107,y=53
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (China)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (China)
 		CityName=Qiqihar
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -49933,7 +49822,7 @@ BeginPlot
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		ReligionType=RELIGION_CONFUCIANISM
-		Player44Culture=50
+		Player44Culture=50, (China)
 	EndCity
 	TeamReveal=1,12,44,
 EndPlot
@@ -49944,7 +49833,7 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	TeamReveal=1,
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=107,y=55
@@ -49952,6 +49841,7 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=107,y=56
@@ -49959,6 +49849,7 @@ BeginPlot
 	isWOfRiver
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=0
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=107,y=57
@@ -50168,33 +50059,20 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=108,y=26
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=44
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_MUSKETMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Makassar
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
@@ -50202,7 +50080,7 @@ BeginPlot
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_ISLAMIC_TEMPLE
 		ReligionType=RELIGION_ISLAM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 	TeamReveal=38,44,
 EndPlot
@@ -50257,8 +50135,8 @@ EndPlot
 BeginPlot
 	x=108,y=34
 	BonusType=BONUS_SUGAR
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
@@ -50358,21 +50236,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=12
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=12
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
 	EndUnit
 	BeginCity
-		CityOwner=12
+		CityOwner=12, (Korea)
 		CityName=Pyongyang
 		CityPopulation=8
 		BuildingType=BUILDING_GRANARY
@@ -50389,7 +50259,7 @@ BeginPlot
 		BuildingType=BUILDING_CONFUCIAN_MONASTERY
 		ReligionType=RELIGION_BUDDHISM
 		ReligionType=RELIGION_CONFUCIANISM
-		Player12Culture=80
+		Player12Culture=80, (Korea)
 	EndCity
 	TeamReveal=1,12,15,45,
 EndPlot
@@ -50438,18 +50308,20 @@ BeginPlot
 	FeatureType=FEATURE_MARSH, FeatureVariety=0
 	TerrainType=TERRAIN_MARSH
 	PlotType=2
-	TeamReveal=1,
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=108,y=55
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=108,y=56
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=0
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=108,y=57
@@ -50661,8 +50533,8 @@ EndPlot
 BeginPlot
 	x=109,y=26
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -50714,23 +50586,13 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_GALLEON, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		PromotionType=PROMOTION_NAVIGATION1
-		PromotionType=PROMOTION_NAVIGATION2
-		FacingDirection=4
-		UnitAIType=UNITAI_ASSAULT_SEA
+		UnitType=UNIT_GALLEON, UnitOwner=22, (Spain)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=22
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=22, (Spain)
 	EndUnit
 	BeginCity
-		CityOwner=22
+		CityOwner=22, (Spain)
 		CityName=Manila
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -50741,15 +50603,15 @@ BeginPlot
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		ReligionType=RELIGION_CATHOLICISM
-		Player22Culture=100
+		Player22Culture=100, (Spain)
 	EndCity
 	TeamReveal=22,29,44,
 EndPlot
 BeginPlot
 	x=109,y=34
 	BonusType=BONUS_BANANA
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -50830,8 +50692,38 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=12, (Korea)
+	EndUnit
 	BeginCity
-		CityOwner=12
+		CityOwner=12, (Korea)
 		CityName=Hanseong
 		CityPopulation=12
 		BuildingType=BUILDING_PALACE
@@ -50852,7 +50744,7 @@ BeginPlot
 		BuildingType=BUILDING_CONFUCIAN_MONASTERY
 		ReligionType=RELIGION_BUDDHISM
 		ReligionType=RELIGION_CONFUCIANISM
-		Player12Culture=250
+		Player12Culture=250, (Korea)
 	EndCity
 	TeamReveal=1,12,15,44,45,
 EndPlot
@@ -50914,19 +50806,21 @@ BeginPlot
 	FeatureType=FEATURE_MARSH, FeatureVariety=0
 	TerrainType=TERRAIN_MARSH
 	PlotType=2
-	TeamReveal=1,
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=109,y=55
 	FeatureType=FEATURE_FOREST, FeatureVariety=2
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=2
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=109,y=56
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=1
+	TeamReveal=1,44,
 EndPlot
 BeginPlot
 	x=109,y=57
@@ -51169,8 +51063,8 @@ EndPlot
 BeginPlot
 	x=110,y=31
 	BonusType=BONUS_SILK
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -51324,7 +51218,7 @@ BeginPlot
 	FeatureType=FEATURE_MARSH, FeatureVariety=0
 	TerrainType=TERRAIN_MARSH
 	PlotType=2
-	TeamReveal=1,15,
+	TeamReveal=1,15,44,
 EndPlot
 BeginPlot
 	x=110,y=54
@@ -51333,7 +51227,7 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_TUNDRA
 	PlotType=1
-	TeamReveal=1,15,
+	TeamReveal=1,15,44,
 EndPlot
 BeginPlot
 	x=110,y=55
@@ -51551,8 +51445,8 @@ EndPlot
 BeginPlot
 	x=111,y=26
 	BonusType=BONUS_DYE
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
@@ -51561,26 +51455,21 @@ EndPlot
 BeginPlot
 	x=111,y=27
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_RIFLEMAN, UnitOwner=38
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_CITY_DEFENSE
+		UnitType=UNIT_RIFLEMAN, UnitOwner=38, (Netherlands)
 	EndUnit
 	BeginCity
-		CityOwner=38
+		CityOwner=38, (Netherlands)
 		CityName=Ambon
 		CityPopulation=5
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_HARBOR
 		ReligionType=RELIGION_ISLAM
-		Player38Culture=50
+		Player38Culture=50, (Netherlands)
 	EndCity
 	TeamReveal=38,44,
 EndPlot
@@ -52065,14 +51954,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
 	EndUnit
 	BeginCity
-		CityOwner=15
+		CityOwner=15, (Japan)
 		CityName=Kagoshima
 		CityPopulation=6
 		BuildingType=BUILDING_GRANARY
@@ -52084,7 +51969,7 @@ BeginPlot
 		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_BUDDHIST_MONASTERY
 		ReligionType=RELIGION_BUDDHISM
-		Player15Culture=100
+		Player15Culture=100, (Japan)
 	EndCity
 	TeamReveal=15,22,29,44,
 EndPlot
@@ -52403,8 +52288,8 @@ EndPlot
 BeginPlot
 	x=113,y=27
 	BonusType=BONUS_SPICES
-	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	ImprovementType=IMPROVEMENT_PLANTATION
+	FeatureType=FEATURE_RAINFOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	TeamReveal=38,
@@ -52517,8 +52402,53 @@ BeginPlot
 	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BOMBARD, UnitOwner=15, (Japan)
+	EndUnit
+(	BeginUnit)
+(		UnitType=UNIT_SETTLER, UnitOwner=15, (Japan)) (AI only)
+(	EndUnit)
 	BeginCity
-		CityOwner=15
+		CityOwner=15, (Japan)
 		CityName=Kyouto
 		CityPopulation=10
 		BuildingType=BUILDING_PALACE
@@ -52538,7 +52468,7 @@ BeginPlot
 		BuildingType=BUILDING_HIMEJI_CASTLE
 		ReligionType=RELIGION_BUDDHISM
 		FreeSpecialistType=SPECIALIST_GREAT_MERCHANT
-		Player15Culture=250
+		Player15Culture=250, (Japan)
 	EndCity
 	TeamReveal=12,15,44,
 EndPlot
@@ -53758,14 +53688,10 @@ BeginPlot
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MUSKETMAN, UnitOwner=15
-		Damage=0
-		Level=1, Experience=0
-		FacingDirection=4
-		UnitAIType=UNITAI_ATTACK
+		UnitType=UNIT_MUSKETMAN, UnitOwner=15, (Japan)
 	EndUnit
 	BeginCity
-		CityOwner=15
+		CityOwner=15, (Japan)
 		CityName=Edo
 		CityPopulation=12
 		BuildingType=BUILDING_GRANARY
@@ -53778,7 +53704,7 @@ BeginPlot
 		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_BUDDHIST_MONASTERY
 		ReligionType=RELIGION_BUDDHISM
-		Player15Culture=100
+		Player15Culture=100, (Japan)
 	EndCity
 	TeamReveal=15,44,
 EndPlot
@@ -56422,5 +56348,3 @@ BeginPlot
 	TerrainType=TERRAIN_COAST
 	PlotType=3
 EndPlot
-
-### Sign Info ###

--- a/PrivateMaps/RFC 3000 BC.CivBeyondSwordWBSave
+++ b/PrivateMaps/RFC 3000 BC.CivBeyondSwordWBSave
@@ -1,3 +1,5 @@
+Platy Builder
+bLoadSpecial=1
 Version=11
 BeginGame
 	Calendar=CALENDAR_DEFAULT
@@ -9,118 +11,170 @@ BeginGame
 	ModPath=Mods\RFC Dawn of Civilization
 EndGame
 BeginTeam
+	TeamID=0, (Egypt)
 	Tech=TECH_THE_WHEEL
 	Tech=TECH_AGRICULTURE
 EndTeam
 BeginTeam
+	TeamID=1, (China)
 	Tech=TECH_AGRICULTURE
 	Tech=TECH_MINING
 EndTeam
 BeginTeam
-	Tech=TECH_AGRICULTURE
+	TeamID=2, (Babylonia)
 	Tech=TECH_THE_WHEEL
-	Tech=TECH_ANIMAL_HUSBANDRY
+	Tech=TECH_AGRICULTURE
 	Tech=TECH_POTTERY
 	Tech=TECH_ARCHERY
+	Tech=TECH_ANIMAL_HUSBANDRY
 EndTeam
 BeginTeam
-	Tech=TECH_AGRICULTURE
+	TeamID=3, (Harappa)
 	Tech=TECH_THE_WHEEL
+	Tech=TECH_AGRICULTURE
 EndTeam
 BeginTeam
+	TeamID=4, (Greece)
 EndTeam
 BeginTeam
+	TeamID=5, (India)
 EndTeam
 BeginTeam
+	TeamID=6, (Phoenicia)
 EndTeam
 BeginTeam
+	TeamID=7, (Polynesia)
 EndTeam
 BeginTeam
+	TeamID=8, (Persia)
 EndTeam
 BeginTeam
+	TeamID=9, (Rome)
 EndTeam
 BeginTeam
+	TeamID=10, (Tamils)
 EndTeam
 BeginTeam
+	TeamID=11, (Ethiopia)
 EndTeam
 BeginTeam
+	TeamID=12, (Korea)
 EndTeam
 BeginTeam
+	TeamID=13, (Maya)
 EndTeam
 BeginTeam
+	TeamID=14, (Byzantium)
 EndTeam
 BeginTeam
+	TeamID=15, (Japan)
 EndTeam
 BeginTeam
+	TeamID=16, (Vikings)
 EndTeam
 BeginTeam
+	TeamID=17, (Arabia)
 EndTeam
 BeginTeam
+	TeamID=18, (Tibet)
 EndTeam
 BeginTeam
+	TeamID=19, (Khmer)
 EndTeam
 BeginTeam
+	TeamID=20, (Indonesia)
 EndTeam
 BeginTeam
+	TeamID=21, (Moors)
 EndTeam
 BeginTeam
+	TeamID=22, (Spain)
 EndTeam
 BeginTeam
+	TeamID=23, (France)
 EndTeam
 BeginTeam
+	TeamID=24, (England)
 EndTeam
 BeginTeam
+	TeamID=25, (HolyRome)
 EndTeam
 BeginTeam
+	TeamID=26, (Russia)
 EndTeam
 BeginTeam
+	TeamID=27, (Mali)
 EndTeam
 BeginTeam
+	TeamID=28, (Poland)
 EndTeam
 BeginTeam
+	TeamID=29, (Portugal)
 EndTeam
 BeginTeam
+	TeamID=30, (Inca)
 EndTeam
 BeginTeam
+	TeamID=31, (Italy)
 EndTeam
 BeginTeam
+	TeamID=32, (Mongols)
 EndTeam
 BeginTeam
+	TeamID=33, (Aztecs)
 EndTeam
 BeginTeam
+	TeamID=34, (Mughals)
 EndTeam
 BeginTeam
+	TeamID=35, (Turkey)
 EndTeam
 BeginTeam
+	TeamID=36, (Thailand)
 EndTeam
 BeginTeam
+	TeamID=37, (Congo)
 EndTeam
 BeginTeam
+	TeamID=38, (Netherlands)
 EndTeam
 BeginTeam
+	TeamID=39, (Germany)
 EndTeam
 BeginTeam
+	TeamID=40, (America)
 EndTeam
 BeginTeam
+	TeamID=41, (Argentina)
 EndTeam
 BeginTeam
+	TeamID=42, (Brazil)
 EndTeam
 BeginTeam
+	TeamID=43, (Canada)
 EndTeam
 BeginTeam
+	TeamID=44, (Independent)
 EndTeam
 BeginTeam
+	TeamID=45, (Independent2)
 EndTeam
 BeginTeam
+	TeamID=46, (Native)
 EndTeam
 BeginTeam
+	TeamID=47, (Celtia)
 EndTeam
 BeginTeam
+	TeamID=48, (Seljuks)
+EndTeam
+BeginTeam
+	TeamID=49, (Barbarian)
 EndTeam
 BeginPlayer
+	Team=0
 	LeaderType=LEADER_RAMESSES
 	CivType=CIVILIZATION_EGYPT
-	Team=0
 	PlayableCiv=1
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
@@ -128,47 +182,50 @@ BeginPlayer
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=1
 	LeaderType=LEADER_QIN_SHI_HUANG
 	CivType=CIVILIZATION_CHINA
-	Team=1
 	PlayableCiv=1
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=2
 	LeaderType=LEADER_HAMMURABI
 	CivType=CIVILIZATION_BABYLONIA
-	Team=2
 	PlayableCiv=1
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=3
 	LeaderType=LEADER_VATAVELLI
 	CivType=CIVILIZATION_HARAPPANS
-	Team=3
 	PlayableCiv=1
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=4
 	LeaderType=LEADER_PERICLES
 	CivType=CIVILIZATION_GREECE
-	Team=4
 	PlayableCiv=1
+	StartingGold=100
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_PANTHEON
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=5
 	LeaderType=LEADER_ASOKA
 	CivType=CIVILIZATION_INDIA
-	Team=5
 	PlayableCiv=1
+	StartingGold=80
 	StateReligion=RELIGION_HINDUISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=6
 	LeaderType=LEADER_HANNIBAL
 	CivType=CIVILIZATION_PHOENICIA
-	Team=6
 	PlayableCiv=1
+	StartingGold=200
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_CITY_STATES
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_PANTHEON
@@ -176,98 +233,108 @@ BeginPlayer
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=7
 	LeaderType=LEADER_AHOEITU
 	CivType=CIVILIZATION_POLYNESIA
-	Team=7
+	Color=PLAYERCOLOR_POLYNESIA
 	PlayableCiv=1
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=8
 	LeaderType=LEADER_CYRUS
 	CivType=CIVILIZATION_PERSIA
-	Team=8
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_ZOROASTRIANISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	StateReligion=RELIGION_ZOROASTRIANISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=9
 	LeaderType=LEADER_AUGUSTUS
 	CivType=CIVILIZATION_ROME
-	Team=9
 	PlayableCiv=1
+	StartingGold=100
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_CITY_STATES
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_PANTHEON
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=10
 	LeaderType=LEADER_RAJENDRA
 	CivType=CIVILIZATION_TAMILS
-	Team=10
 	PlayableCiv=1
+	StartingGold=200
 	StateReligion=RELIGION_HINDUISM
-	CivicOption=CIVICOPTION_GOVERNMENT, Civic_CIVIC_DYNASTICISM
+	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=11
 	LeaderType=LEADER_ZARA_YAQOB
 	CivType=CIVILIZATION_ETHIOPIA
-	Team=11
 	PlayableCiv=1
+	StartingGold=100
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=12
 	LeaderType=LEADER_WANGKON
 	CivType=CIVILIZATION_KOREA
-	Team=12
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_BUDDHISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	StateReligion=RELIGION_BUDDHISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=13
 	LeaderType=LEADER_PACAL
 	CivType=CIVILIZATION_MAYA
-	Team=13
 	PlayableCiv=1
+	StartingGold=200
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_PANTHEON
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=14
 	LeaderType=LEADER_JUSTINIAN
 	CivType=CIVILIZATION_BYZANTIUM
-	Team=14
 	PlayableCiv=1
+	StartingGold=400
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_MERCENARIES
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=15
 	LeaderType=LEADER_TOKUGAWA
 	CivType=CIVILIZATION_JAPAN
-	Team=15
 	PlayableCiv=1
+	StartingGold=100
+	StateReligion=RELIGION_BUDDHISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	StateReligion=RELIGION_BUDDHISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=16
 	LeaderType=LEADER_RAGNAR
 	CivType=CIVILIZATION_VIKING
-	Team=16
 	PlayableCiv=1
+	StartingGold=150
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
@@ -275,389 +342,423 @@ BeginPlayer
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=17
 	LeaderType=LEADER_SALADIN
 	CivType=CIVILIZATION_ARABIA
-	Team=17
 	PlayableCiv=1
+	StartingGold=300
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_FANATICISM
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=18
 	LeaderType=LEADER_LOBSANG_GYATSO
 	CivType=CIVILIZATION_TIBET
-	Team=18
 	PlayableCiv=1
+	StartingGold=50
+	StateReligion=RELIGION_BUDDHISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
-	StateReligion=RELIGION_BUDDHISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=19
 	LeaderType=LEADER_SURYAVARMAN
 	CivType=CIVILIZATION_KHMER
-	Team=19
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_HINDUISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
-	StateReligion=RELIGION_HINDUISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=20
 	LeaderType=LEADER_HAYAM_WURUK
 	CivType=CIVILIZATION_INDONESIA
-	Team=20
 	PlayableCiv=1
+	StartingGold=300
+	StateReligion=RELIGION_BUDDHISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
-	StateReligion=RELIGION_BUDDHISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=21
 	LeaderType=LEADER_RAHMAN
 	CivType=CIVILIZATION_MOORS
-	Team=21
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_SCHOLASTICISM
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=22
 	LeaderType=LEADER_ISABELLA
 	CivType=CIVILIZATION_SPAIN
-	Team=22
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=23
 	LeaderType=LEADER_LOUIS_XIV
 	CivType=CIVILIZATION_FRANCE
-	Team=23
 	PlayableCiv=1
+	StartingGold=150
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=24
 	LeaderType=LEADER_VICTORIA
 	CivType=CIVILIZATION_ENGLAND
-	Team=24
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=25
 	LeaderType=LEADER_BARBAROSSA
 	CivType=CIVILIZATION_HOLY_ROMAN
-	Team=25
 	PlayableCiv=1
+	StartingGold=150
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=26
 	LeaderType=LEADER_STALIN
 	CivType=CIVILIZATION_RUSSIA
-	Team=26
 	PlayableCiv=1
+	StartingGold=200
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
 	Handicap=HANDICAP_REGENT
+	StateReligionBuilding=25
 EndPlayer
 BeginPlayer
+	Team=27
 	LeaderType=LEADER_MANSA_MUSA
 	CivType=CIVILIZATION_MALI
-	Team=27
 	PlayableCiv=1
+	StartingGold=600
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=28
 	LeaderType=LEADER_SOBIESKI
 	CivType=CIVILIZATION_POLAND
-	Team=28
 	PlayableCiv=1
+	StartingGold=100
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=29
 	LeaderType=LEADER_JOAO
 	CivType=CIVILIZATION_PORTUGAL
-	Team=29
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
+	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=30
 	LeaderType=LEADER_HUAYNA_CAPAC
 	CivType=CIVILIZATION_INCA
-	Team=30
 	PlayableCiv=1
+	StartingGold=700
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_PANTHEON
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=31
 	LeaderType=LEADER_CAVOUR
 	CivType=CIVILIZATION_ITALY
-	Team=31
 	PlayableCiv=1
+	StartingGold=350
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_CITY_STATES
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
-	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
+	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=32
 	LeaderType=LEADER_GENGHIS_KHAN
 	CivType=CIVILIZATION_MONGOL
-	Team=32
 	PlayableCiv=1
+	StartingGold=250
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=33
 	LeaderType=LEADER_MONTEZUMA
 	CivType=CIVILIZATION_AZTEC
-	Team=33
 	PlayableCiv=1
+	StartingGold=600
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_PANTHEON
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=34
 	LeaderType=LEADER_AKBAR
 	CivType=CIVILIZATION_MUGHALS
-	Team=34
 	PlayableCiv=1
+	StartingGold=400
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
+	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
-	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=35
 	LeaderType=LEADER_MEHMED
 	CivType=CIVILIZATION_OTTOMAN
-	Team=35
 	PlayableCiv=1
+	StartingGold=300
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=36
 	LeaderType=LEADER_NARESUAN
 	CivType=CIVILIZATION_THAILAND
-	Team=36
 	PlayableCiv=1
-	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
-	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
+	StartingGold=800
 	StateReligion=RELIGION_BUDDHISM
+	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
+	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
+	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=37
 	LeaderType=LEADER_MBEMBA
 	CivType=CIVILIZATION_CONGO
-	Team=37
 	PlayableCiv=1
+	StartingGold=300
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=38
 	LeaderType=LEADER_WILLEM_VAN_ORANJE
 	CivType=CIVILIZATION_NETHERLANDS
-	Team=38
 	PlayableCiv=1
+	StartingGold=600
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_CITY_STATES
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_MERCENARIES
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=39
 	LeaderType=LEADER_FREDERICK
 	CivType=CIVILIZATION_GERMANY
-	Team=39
 	PlayableCiv=1
+	StartingGold=800
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=40
 	LeaderType=LEADER_FRANKLIN_ROOSEVELT
 	CivType=CIVILIZATION_AMERICA
-	Team=40
 	PlayableCiv=1
+	StartingGold=1500
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_REPUBLIC
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_SECULARISM
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=41
 	LeaderType=LEADER_SAN_MARTIN
 	CivType=CIVILIZATION_ARGENTINA
-	Team=41
 	PlayableCiv=1
+	StartingGold=1200
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_AUTOCRACY
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_SECULARISM
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=42
 	LeaderType=LEADER_DOM_PEDRO
 	CivType=CIVILIZATION_BRAZIL
-	Team=42
 	PlayableCiv=1
+	StartingGold=1600
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=43
 	LeaderType=LEADER_TRUDEAU
 	CivType=CIVILIZATION_CANADA
-	Team=43
 	PlayableCiv=1
+	StartingGold=1000
+	StateReligion=RELIGION_ORTHODOXY
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=44
 	LeaderType=LEADER_INDEPENDENT
 	CivType=CIVILIZATION_INDEPENDENT
-	Team=44
 	PlayableCiv=0
 	MinorNationStatus=1
+	StartingGold=50
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=45
 	LeaderType=LEADER_INDEPENDENT
 	CivType=CIVILIZATION_INDEPENDENT2
-	Team=45
 	PlayableCiv=0
 	MinorNationStatus=1
+	StartingGold=50
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=46
 	LeaderType=LEADER_NATIVE
 	CivType=CIVILIZATION_NATIVE
-	Team=46
 	PlayableCiv=0
 	MinorNationStatus=1
+	StartingGold=100
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=47
 	LeaderType=LEADER_BRENNUS
 	CivType=CIVILIZATION_CELT
-	Team=47
 	PlayableCiv=0
 	MinorNationStatus=1
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=48
 	LeaderType=LEADER_ALP
 	CivType=CIVILIZATION_SELJUK
-	StateReligion=RELIGION_ISLAM
-	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ANIMISM
+	Color=PLAYERCOLOR_SELJUK
+	ArtStyle=ARTSTYLE_MIDDLE_EAST
+	PlayableCiv=0
 	MinorNationStatus=1
-	Team=48
+	StartingGold=250
+	Handicap=HANDICAP_REGENT
+EndPlayer
+BeginPlayer
+	Team=49
+	LeaderType=LEADER_BARBARIAN
+	CivType=CIVILIZATION_BARBARIAN
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
-
 BeginMap
 	grid width=124
 	grid height=68
-	wrap X=1
-	wrap Y=0
 	top latitude=90
 	bottom latitude=-90
+	wrap X=1
+	wrap Y=0
 	world size=WORLDSIZE_HUGE
 	climate=CLIMATE_TEMPERATE
 	sealevel=SEALEVEL_MEDIUM
@@ -26415,6 +26516,12 @@ BeginPlot
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_WARRIOR, UnitOwner=0, (Egypt)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=0, (Egypt)
+	EndUnit
 EndPlot
 BeginPlot
 	x=69,y=34
@@ -29119,6 +29226,12 @@ BeginPlot
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_WARRIOR, UnitOwner=2, (Babylonia)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=2, (Babylonia)
+	EndUnit
 EndPlot
 BeginPlot
 	x=76,y=41
@@ -38184,6 +38297,12 @@ BeginPlot
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	BeginUnit
+		UnitType=UNIT_WARRIOR, UnitOwner=1, (China)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=1, (China)
+	EndUnit
 EndPlot
 BeginPlot
 	x=100,y=45

--- a/PrivateMaps/RFC 600 AD.CivBeyondSwordWBSave
+++ b/PrivateMaps/RFC 600 AD.CivBeyondSwordWBSave
@@ -1,3 +1,5 @@
+Platy Builder
+bLoadSpecial=1
 Version=11
 BeginGame
 	Calendar=CALENDAR_DEFAULT
@@ -9,241 +11,294 @@ BeginGame
 	ModPath=Mods\RFC Dawn of Civilization
 EndGame
 BeginTeam
+	TeamID=0, (Egypt)
 EndTeam
 BeginTeam
+	TeamID=1, (China)
 EndTeam
 BeginTeam
+	TeamID=2, (Babylonia)
 EndTeam
 BeginTeam
+	TeamID=3, (Harappa)
 EndTeam
 BeginTeam
+	TeamID=4, (Greece)
 EndTeam
 BeginTeam
+	TeamID=5, (India)
 EndTeam
 BeginTeam
+	TeamID=6, (Phoenicia)
 EndTeam
 BeginTeam
+	TeamID=7, (Polynesia)
 EndTeam
 BeginTeam
+	TeamID=8, (Persia)
 EndTeam
 BeginTeam
+	TeamID=9, (Rome)
 EndTeam
 BeginTeam
+	TeamID=10, (Tamils)
 EndTeam
 BeginTeam
+	TeamID=11, (Ethiopia)
 EndTeam
 BeginTeam
+	TeamID=12, (Korea)
 EndTeam
 BeginTeam
+	TeamID=13, (Maya)
 EndTeam
 BeginTeam
+	TeamID=14, (Byzantium)
 EndTeam
 BeginTeam
+	TeamID=15, (Japan)
 EndTeam
 BeginTeam
+	TeamID=16, (Vikings)
 EndTeam
 BeginTeam
+	TeamID=17, (Arabia)
 EndTeam
 BeginTeam
+	TeamID=18, (Tibet)
 EndTeam
 BeginTeam
+	TeamID=19, (Khmer)
 EndTeam
 BeginTeam
+	TeamID=20, (Indonesia)
 EndTeam
 BeginTeam
+	TeamID=21, (Moors)
 EndTeam
 BeginTeam
+	TeamID=22, (Spain)
 EndTeam
 BeginTeam
+	TeamID=23, (France)
 EndTeam
 BeginTeam
+	TeamID=24, (England)
 EndTeam
 BeginTeam
+	TeamID=25, (HolyRome)
 EndTeam
 BeginTeam
+	TeamID=26, (Russia)
 EndTeam
 BeginTeam
+	TeamID=27, (Mali)
 EndTeam
 BeginTeam
+	TeamID=28, (Poland)
 EndTeam
 BeginTeam
+	TeamID=29, (Portugal)
 EndTeam
 BeginTeam
+	TeamID=30, (Inca)
 EndTeam
 BeginTeam
+	TeamID=31, (Italy)
 EndTeam
 BeginTeam
+	TeamID=32, (Mongols)
 EndTeam
 BeginTeam
+	TeamID=33, (Aztecs)
 EndTeam
 BeginTeam
+	TeamID=34, (Mughals)
 EndTeam
 BeginTeam
+	TeamID=35, (Turkey)
 EndTeam
 BeginTeam
+	TeamID=36, (Thailand)
 EndTeam
 BeginTeam
+	TeamID=37, (Congo)
 EndTeam
 BeginTeam
+	TeamID=38, (Netherlands)
 EndTeam
 BeginTeam
+	TeamID=39, (Germany)
 EndTeam
 BeginTeam
+	TeamID=40, (America)
 EndTeam
 BeginTeam
+	TeamID=41, (Argentina)
 EndTeam
 BeginTeam
+	TeamID=42, (Brazil)
 EndTeam
 BeginTeam
+	TeamID=43, (Canada)
 EndTeam
 BeginTeam
+	TeamID=44, (Independent)
 EndTeam
 BeginTeam
+	TeamID=45, (Independent2)
 EndTeam
 BeginTeam
+	TeamID=46, (Native)
 EndTeam
 BeginTeam
+	TeamID=47, (Celtia)
 EndTeam
 BeginTeam
+	TeamID=48, (Seljuks)
+EndTeam
+BeginTeam
+	TeamID=49, (Barbarian)
 EndTeam
 BeginPlayer
+	Team=0
 	LeaderType=LEADER_RAMESSES
 	CivType=CIVILIZATION_EGYPT
-	Team=0
 	PlayableCiv=0
-	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_PANTHEON
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=1
 	LeaderType=LEADER_TAIZONG
 	CivType=CIVILIZATION_CHINA
-	Team=1
 	PlayableCiv=1
-	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
-	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ANIMISM
+	StartingGold=300
 	StateReligion=RELIGION_CONFUCIANISM
+	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
+	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=2
 	LeaderType=LEADER_HAMMURABI
 	CivType=CIVILIZATION_BABYLONIA
-	Team=2
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=3
 	LeaderType=LEADER_VATAVELLI
 	CivType=CIVILIZATION_HARAPPANS
-	Team=3
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=4
 	LeaderType=LEADER_PERICLES
 	CivType=CIVILIZATION_GREECE
-	Team=4
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=5
 	LeaderType=LEADER_ASOKA
 	CivType=CIVILIZATION_INDIA
-	Team=5
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=6
 	LeaderType=LEADER_HANNIBAL
 	CivType=CIVILIZATION_PHOENICIA
-	Team=6
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=7
 	LeaderType=LEADER_AHOEITU
 	CivType=CIVILIZATION_POLYNESIA
-	Team=7
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=8
 	LeaderType=LEADER_CYRUS
 	CivType=CIVILIZATION_PERSIA
-	Team=8
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=9
 	LeaderType=LEADER_AUGUSTUS
 	CivType=CIVILIZATION_ROME
-	Team=9
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=10
 	LeaderType=LEADER_RAJENDRA
 	CivType=CIVILIZATION_TAMILS
-	Team=10
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=11
 	LeaderType=LEADER_ZARA_YAQOB
 	CivType=CIVILIZATION_ETHIOPIA
-	Team=11
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=12
 	LeaderType=LEADER_WANGKON
 	CivType=CIVILIZATION_KOREA
-	Team=12
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_BUDDHISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
-	StateReligion=RELIGION_BUDDHISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=13
 	LeaderType=LEADER_PACAL
 	CivType=CIVILIZATION_MAYA
-	Team=13
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=14
 	LeaderType=LEADER_JUSTINIAN
 	CivType=CIVILIZATION_BYZANTIUM
-	Team=14
 	PlayableCiv=1
-	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
-	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
-	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_MERCENARIES
+	StartingGold=400
 	StateReligion=RELIGION_ORTHODOXY
+	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
+	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
+	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_MERCENARIES
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=15
 	LeaderType=LEADER_TOKUGAWA
 	CivType=CIVILIZATION_JAPAN
-	Team=15
 	PlayableCiv=1
-	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	StartingGold=300
 	StateReligion=RELIGION_BUDDHISM
+	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
+	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=16
 	LeaderType=LEADER_RAGNAR
 	CivType=CIVILIZATION_VIKING
-	Team=16
 	PlayableCiv=1
+	StartingGold=150
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
@@ -251,391 +306,425 @@ BeginPlayer
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=17
 	LeaderType=LEADER_SALADIN
 	CivType=CIVILIZATION_ARABIA
-	Team=17
 	PlayableCiv=1
+	StartingGold=300
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_FANATICISM
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=18
 	LeaderType=LEADER_LOBSANG_GYATSO
 	CivType=CIVILIZATION_TIBET
-	Team=18
 	PlayableCiv=1
+	StartingGold=50
+	StateReligion=RELIGION_BUDDHISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
-	StateReligion=RELIGION_BUDDHISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=19
 	LeaderType=LEADER_SURYAVARMAN
 	CivType=CIVILIZATION_KHMER
-	Team=19
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_HINDUISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
-	StateReligion=RELIGION_HINDUISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=20
 	LeaderType=LEADER_HAYAM_WURUK
 	CivType=CIVILIZATION_INDONESIA
-	Team=20
 	PlayableCiv=1
+	StartingGold=300
+	StateReligion=RELIGION_BUDDHISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
-	StateReligion=RELIGION_BUDDHISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=21
 	LeaderType=LEADER_RAHMAN
 	CivType=CIVILIZATION_MOORS
-	Team=21
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_SCHOLASTICISM
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=22
 	LeaderType=LEADER_ISABELLA
 	CivType=CIVILIZATION_SPAIN
-	Team=22
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=23
 	LeaderType=LEADER_LOUIS_XIV
 	CivType=CIVILIZATION_FRANCE
-	Team=23
 	PlayableCiv=1
+	StartingGold=150
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=24
 	LeaderType=LEADER_VICTORIA
 	CivType=CIVILIZATION_ENGLAND
-	Team=24
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=25
 	LeaderType=LEADER_BARBAROSSA
 	CivType=CIVILIZATION_HOLY_ROMAN
-	Team=25
 	PlayableCiv=1
+	StartingGold=150
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=26
 	LeaderType=LEADER_STALIN
 	CivType=CIVILIZATION_RUSSIA
-	Team=26
 	PlayableCiv=1
+	StartingGold=200
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=27
 	LeaderType=LEADER_MANSA_MUSA
 	CivType=CIVILIZATION_MALI
-	Team=27
 	PlayableCiv=1
+	StartingGold=600
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=28
 	LeaderType=LEADER_SOBIESKI
 	CivType=CIVILIZATION_POLAND
-	Team=28
 	PlayableCiv=1
+	StartingGold=100
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=29
 	LeaderType=LEADER_JOAO
 	CivType=CIVILIZATION_PORTUGAL
-	Team=29
 	PlayableCiv=1
+	StartingGold=200
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_VASSALAGE
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
+	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=30
 	LeaderType=LEADER_HUAYNA_CAPAC
 	CivType=CIVILIZATION_INCA
-	Team=30
 	PlayableCiv=1
+	StartingGold=700
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_PANTHEON
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=31
 	LeaderType=LEADER_CAVOUR
 	CivType=CIVILIZATION_ITALY
-	Team=31
 	PlayableCiv=1
+	StartingGold=350
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_CITY_STATES
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
-	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
+	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=32
 	LeaderType=LEADER_GENGHIS_KHAN
 	CivType=CIVILIZATION_MONGOL
-	Team=32
 	PlayableCiv=1
+	StartingGold=250
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=33
 	LeaderType=LEADER_MONTEZUMA
 	CivType=CIVILIZATION_AZTEC
-	Team=33
 	PlayableCiv=1
+	StartingGold=600
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_PANTHEON
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=34
 	LeaderType=LEADER_AKBAR
 	CivType=CIVILIZATION_MUGHALS
-	Team=34
 	PlayableCiv=1
+	StartingGold=400
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
+	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
-	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=35
 	LeaderType=LEADER_MEHMED
 	CivType=CIVILIZATION_OTTOMAN
-	Team=35
 	PlayableCiv=1
+	StartingGold=300
+	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_GUILDS
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_LEVY_ARMIES
-	StateReligion=RELIGION_ISLAM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=36
 	LeaderType=LEADER_NARESUAN
 	CivType=CIVILIZATION_THAILAND
-	Team=36
 	PlayableCiv=1
-	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
-	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
+	StartingGold=800
 	StateReligion=RELIGION_BUDDHISM
+	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
+	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
+	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=37
 	LeaderType=LEADER_MBEMBA
 	CivType=CIVILIZATION_CONGO
-	Team=37
 	PlayableCiv=1
+	StartingGold=300
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=38
 	LeaderType=LEADER_WILLEM_VAN_ORANJE
 	CivType=CIVILIZATION_NETHERLANDS
-	Team=38
 	PlayableCiv=1
+	StartingGold=600
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_CITY_STATES
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_AGRARIANISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_MERCENARIES
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=39
 	LeaderType=LEADER_FREDERICK
 	CivType=CIVILIZATION_GERMANY
-	Team=39
 	PlayableCiv=1
+	StartingGold=800
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_ABSOLUTISM
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=40
 	LeaderType=LEADER_FRANKLIN_ROOSEVELT
 	CivType=CIVILIZATION_AMERICA
-	Team=40
 	PlayableCiv=1
+	StartingGold=1500
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_REPUBLIC
-	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
+	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_SECULARISM
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=41
 	LeaderType=LEADER_SAN_MARTIN
 	CivType=CIVILIZATION_ARGENTINA
-	Team=41
 	PlayableCiv=1
+	StartingGold=1200
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_AUTOCRACY
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_SECULARISM
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=42
 	LeaderType=LEADER_DOM_PEDRO
 	CivType=CIVILIZATION_BRAZIL
-	Team=42
 	PlayableCiv=1
+	StartingGold=1600
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_CATHOLICISM
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=43
 	LeaderType=LEADER_TRUDEAU
 	CivType=CIVILIZATION_CANADA
-	Team=43
 	PlayableCiv=1
+	StartingGold=1000
+	StateReligion=RELIGION_CATHOLICISM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_DYNASTICISM
 	CivicOption=CIVICOPTION_ORGANIZATION, Civic=CIVIC_REPRESENTATION
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_CAPITALISM
 	CivicOption=CIVICOPTION_ECONOMY, Civic=CIVIC_MERCANTILISM
 	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ORGANIZED_RELIGION
 	CivicOption=CIVICOPTION_MILITARY, Civic=CIVIC_STANDING_ARMY
-	StateReligion=RELIGION_ORTHODOXY
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=44
 	LeaderType=LEADER_INDEPENDENT
 	CivType=CIVILIZATION_INDEPENDENT
-	Team=44
 	PlayableCiv=0
 	MinorNationStatus=1
+	StartingGold=100
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=45
 	LeaderType=LEADER_INDEPENDENT
 	CivType=CIVILIZATION_INDEPENDENT2
-	Team=45
 	PlayableCiv=0
 	MinorNationStatus=1
+	StartingGold=100
 	Handicap=HANDICAP_REGENT
-	StateReligion=RELIGION_CATHOLICISM
 EndPlayer
 BeginPlayer
+	Team=46
 	LeaderType=LEADER_NATIVE
 	CivType=CIVILIZATION_NATIVE
-	Team=46
 	PlayableCiv=0
 	MinorNationStatus=1
+	StartingGold=300
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=47
 	LeaderType=LEADER_JUSTINIAN
 	CivType=CIVILIZATION_BYZANTIUM
-	StateReligion=RELIGION_CATHOLICISM
-	Team=47
 	PlayableCiv=0
 	MinorNationStatus=1
 	Handicap=HANDICAP_REGENT
 EndPlayer
 BeginPlayer
+	Team=48
 	LeaderType=LEADER_ALP
 	CivType=CIVILIZATION_SELJUK
+	Color=PLAYERCOLOR_SELJUK
+	ArtStyle=ARTSTYLE_MIDDLE_EAST
+	PlayableCiv=0
+	MinorNationStatus=1
+	StartingGold=250
 	StateReligion=RELIGION_ISLAM
 	CivicOption=CIVICOPTION_GOVERNMENT, Civic=CIVIC_THEOCRACY
 	CivicOption=CIVICOPTION_LABOR, Civic=CIVIC_SLAVERY
-	CivicOption=CIVICOPTION_RELIGION, Civic=CIVIC_ANIMISM
-	MinorNationStatus=1
-	Team=48
+	Handicap=HANDICAP_REGENT
+EndPlayer
+BeginPlayer
+	Team=49
+	LeaderType=LEADER_BARBARIAN
+	CivType=CIVILIZATION_BARBARIAN
 	PlayableCiv=0
 	Handicap=HANDICAP_REGENT
 EndPlayer
-
 BeginMap
 	grid width=124
 	grid height=68
-	wrap X=1
-	wrap Y=0
 	top latitude=90
 	bottom latitude=-90
+	wrap X=1
+	wrap Y=0
 	world size=WORLDSIZE_HUGE
 	climate=CLIMATE_TEMPERATE
 	sealevel=SEALEVEL_MEDIUM
@@ -7117,7 +7206,7 @@ EndPlot
 BeginPlot
 	x=17,y=65
 	TerrainType=TERRAIN_SNOW
-	PlotType=3
+	PlotType=2
 EndPlot
 BeginPlot
 	x=17,y=66
@@ -8803,18 +8892,18 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=22,y=35
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MAYAN_HOLKAN, UnitOwner=46
+		UnitType=UNIT_MAYAN_HOLKAN, UnitOwner=46, (Native)
 	EndUnit
 	BeginCity
-		CityOwner=46
+		CityOwner=46, (Native)
 		CityName=Yax Mutal
 		CityPopulation=2
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_MAYAN_BALL_COURT
-		Player46Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -9209,21 +9298,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=23,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MAYAN_HOLKAN, UnitOwner=46
+		UnitType=UNIT_MAYAN_HOLKAN, UnitOwner=46, (Native)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_WORKER, UnitOwner=46
+		UnitType=UNIT_WORKER, UnitOwner=46, (Native)
 	EndUnit
 	BeginCity
-		CityOwner=46
+		CityOwner=46, (Native)
 		CityName=Chich'en Itz&#225;
 		CityPopulation=2
 		BuildingType=BUILDING_MAYAN_BALL_COURT
 		BuildingType=BUILDING_TEMPLE_OF_KUKULKAN
-		Player46Culture=10
+		Player46Culture=10, (Native)
 	EndCity
 EndPlot
 BeginPlot
@@ -19515,19 +19605,19 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=51,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Marrakus
 		CityPopulation=2
-		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		Player44Culture=1
+		BuildingType=BUILDING_HARBOR
 	EndCity
 EndPlot
 BeginPlot
@@ -19958,9 +20048,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=52,y=47
@@ -20339,26 +20429,26 @@ EndPlot
 BeginPlot
 	x=53,y=47
 	BonusType=BONUS_WINE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=53,y=48
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Burdigala
 		CityPopulation=3
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
 		ReligionType=RELIGION_CATHOLICISM
-		Player44Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -20699,17 +20789,17 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=54,y=42
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=54,y=43
 	BonusType=BONUS_SILVER
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=54,y=44
@@ -20737,9 +20827,9 @@ BeginPlot
 	RiverNSDirection=0
 	isWOfRiver
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=54,y=48
@@ -21092,28 +21182,27 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=55,y=44
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=45
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Barcelona
 		CityPopulation=2
-		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_HARBOR
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
-		Player45Culture=1
 	EndCity
 EndPlot
 BeginPlot
 	x=55,y=45
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=55,y=46
@@ -21123,9 +21212,9 @@ EndPlot
 BeginPlot
 	x=55,y=47
 	BonusType=BONUS_WHEAT
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=55,y=48
@@ -21483,22 +21572,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=56,y=46
-	isWOfRiver
 	RiverNSDirection=2
+	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Massilia
 		CityPopulation=3
-		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_HARBOR
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
-		Player44Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -21507,25 +21596,25 @@ BeginPlot
 	isWOfRiver
 	BonusType=BONUS_ALUMINUM
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=56,y=48
 	RiverNSDirection=2
 	isWOfRiver
 	BonusType=BONUS_WINE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=56,y=49
 	BonusType=BONUS_PIG
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=56,y=50
@@ -21829,9 +21918,9 @@ BeginPlot
 	RiverWEDirection=1
 	isWOfRiver
 	BonusType=BONUS_SHEEP
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=57,y=40
@@ -21866,9 +21955,9 @@ EndPlot
 BeginPlot
 	x=57,y=46
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=57,y=47
@@ -22182,22 +22271,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=58,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=58,y=38
 	BonusType=BONUS_STONE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=58,y=39
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=58,y=40
@@ -22233,9 +22322,9 @@ EndPlot
 BeginPlot
 	x=58,y=46
 	BonusType=BONUS_STONE
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=58,y=47
@@ -22555,9 +22644,9 @@ EndPlot
 BeginPlot
 	x=59,y=37
 	BonusType=BONUS_WHEAT
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=59,y=38
@@ -22606,9 +22695,9 @@ EndPlot
 BeginPlot
 	x=59,y=46
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=59,y=47
@@ -22938,19 +23027,20 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=60,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_SPEARMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Tripolis
 		CityPopulation=2
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -22988,61 +23078,62 @@ BeginPlot
 	x=60,y=44
 	RiverNSDirection=2
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=45
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=45
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
+		UnitType=UNIT_PIKEMAN, UnitOwner=45, (Independent2)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
+		UnitType=UNIT_PIKEMAN, UnitOwner=45, (Independent2)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CATHOLIC_MISSIONARY, UnitOwner=45
+		UnitType=UNIT_CATHOLIC_MISSIONARY, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_WORKER, UnitOwner=45
+		UnitType=UNIT_WORKER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Roma
 		CityPopulation=4
-		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_ROMAN_FORUM
-		BuildingType=BUILDING_COLOSSEUM
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		BuildingType=BUILDING_CATHOLIC_SHRINE
+		BuildingType=BUILDING_COLOSSEUM
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
 		HolyCityReligionType=RELIGION_CATHOLICISM
-		Player45Culture=100
+		Player45Culture=100, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
 	x=60,y=45
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=60,y=46
@@ -23056,9 +23147,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	BonusType=BONUS_WHEAT
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=60,y=48
@@ -23117,6 +23208,12 @@ BeginPlot
 	x=60,y=56
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+(	BeginUnit)
+(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)) (AI only)
+(	EndUnit)
 EndPlot
 BeginPlot
 	x=60,y=57
@@ -23127,11 +23224,66 @@ BeginPlot
 	x=60,y=58
 	TerrainType=TERRAIN_COAST
 	PlotType=3
+	BeginUnit
+		UnitType=UNIT_GALLEY, UnitOwner=16, (Vikings)
+		UnitAIType=UNITAI_SETTLER_SEA
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEY, UnitOwner=16, (Vikings)
+		UnitAIType=UNITAI_EXPLORE_SEA
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEY, UnitOwner=16, (Vikings)
+		UnitAIType=UNITAI_EXPLORE_SEA
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_WORK_BOAT, UnitOwner=16, (Vikings)
+	EndUnit
+(	BeginUnit)
+(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (Human only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)) (Human only)
+(	EndUnit)
 EndPlot
 BeginPlot
 	x=60,y=59
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+(	BeginUnit)
+(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (Human only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (Human only)
+(	EndUnit)
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SWORDSMAN, UnitOwner=16, (Vikings)
+		UnitAIType=UNITAI_ATTACK_CITY
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SWORDSMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_AXEMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_AXEMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SCOUT, UnitOwner=16, (Vikings)
+	EndUnit
+(	BeginUnit)
+(		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)) (Human only)
+(	EndUnit)
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)
+	EndUnit
 EndPlot
 BeginPlot
 	x=60,y=60
@@ -23378,9 +23530,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=61,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=61,y=38
@@ -23410,9 +23562,9 @@ EndPlot
 BeginPlot
 	x=61,y=43
 	BonusType=BONUS_PIG
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=61,y=44
@@ -23435,43 +23587,42 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=61,y=47
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=44
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44, (Independent)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44
+		UnitType=UNIT_PIKEMAN, UnitOwner=44, (Independent)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Venetia
 		CityPopulation=2
-		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_STABLE
+		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_MARKET
 		ReligionType=RELIGION_CATHOLICISM
-		Player44Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -23794,9 +23945,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=62,y=36
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=62,y=37
@@ -23827,20 +23978,19 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=62,y=42
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
-		CityName=Napoli
+		CityOwner=14, (Byzantium)
+		CityName=Neapolis
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
 		ReligionType=RELIGION_CATHOLICISM
-		Player44Culture=10
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -23879,19 +24029,19 @@ BeginPlot
 	x=62,y=49
 	RiverNSDirection=2
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Vindobona
 		CityPopulation=1
 		BuildingType=BUILDING_GRANARY
-		Player45Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -24205,9 +24355,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=63,y=36
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=63,y=37
@@ -24237,9 +24387,9 @@ EndPlot
 BeginPlot
 	x=63,y=42
 	BonusType=BONUS_SHEEP
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=63,y=43
@@ -24343,6 +24493,12 @@ BeginPlot
 	RiverWEDirection=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+(	BeginUnit)
+(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)) (AI only)
+(	EndUnit)
 EndPlot
 BeginPlot
 	x=63,y=60
@@ -24599,16 +24755,17 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=64,y=36
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=44
+		UnitType=UNIT_SPEARMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Hesperides
 		CityPopulation=2
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -25017,9 +25174,9 @@ EndPlot
 BeginPlot
 	x=65,y=37
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=65,y=38
@@ -25049,9 +25206,9 @@ EndPlot
 BeginPlot
 	x=65,y=43
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=65,y=44
@@ -25061,19 +25218,19 @@ EndPlot
 BeginPlot
 	x=65,y=45
 	BonusType=BONUS_ALUMINUM
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
-		CityName=Belgrad
+		CityOwner=14, (Byzantium)
+		CityName=Singidunon
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
 		ReligionType=RELIGION_ORTHODOXY
-		Player44Culture=10
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -25439,9 +25596,9 @@ BeginPlot
 	x=66,y=37
 	BonusType=BONUS_DYE
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=66,y=38
@@ -25469,10 +25626,10 @@ EndPlot
 BeginPlot
 	x=66,y=42
 	BonusType=BONUS_IRON
-	TerrainType=TERRAIN_PLAINS
-	PlotType=1
 	ImprovementType=IMPROVEMENT_MINE
 	RouteType=ROUTE_ROMAN_ROAD
+	TerrainType=TERRAIN_PLAINS
+	PlotType=1
 EndPlot
 BeginPlot
 	x=66,y=43
@@ -25483,9 +25640,9 @@ BeginPlot
 	x=66,y=44
 	BonusType=BONUS_SHEEP
 	ImprovementType=IMPROVEMENT_PASTURE
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=66,y=45
@@ -25849,14 +26006,15 @@ BeginPlot
 	x=67,y=36
 	RiverNSDirection=0
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=44
+		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
-		CityName=Alexandria
+		CityOwner=14, (Byzantium)
+		CityName=Alexandreia
 		CityPopulation=3
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_GREAT_LIGHTHOUSE
@@ -25864,7 +26022,7 @@ BeginPlot
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_CATHOLICISM
-		Player44Culture=10
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -25890,30 +26048,30 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=67,y=41
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_WORKER, UnitOwner=44
+		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=44
+		UnitType=UNIT_WORKER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
-		CityName=Athenae
+		CityOwner=14, (Byzantium)
+		CityName=Athinai
 		CityPopulation=3
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_PAGAN_TEMPLE
 		BuildingType=BUILDING_LIBRARY
-		BuildingType=BUILDING_THEATRE
-		BuildingType=BUILDING_GREEK_ODEON
+		BuildingType=BUILDING_BYZANTINE_HIPPODROME
+		BuildingType=BUILDING_PARTHENON
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
-		BuildingType=BUILDING_PARTHENON
-		Player44Culture=50
+		Player14Culture=50, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -25930,9 +26088,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=67,y=44
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=67,y=45
@@ -26300,9 +26458,9 @@ BeginPlot
 	RiverWEDirection=0
 	isWOfRiver
 	BonusType=BONUS_WHEAT
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=68,y=37
@@ -26348,11 +26506,72 @@ BeginPlot
 	BonusType=BONUS_FISH
 	TerrainType=TERRAIN_COAST
 	PlotType=3
+	BeginUnit
+		UnitType=UNIT_TRIREME, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_TRIREME, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEY, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEY, UnitOwner=14, (Byzantium)
+	EndUnit
 EndPlot
 BeginPlot
 	x=68,y=45
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_BYZANTINE_CATAPHRACT, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_WORKER, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_WORKER, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_WORKER, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginCity
+		CityOwner=14, (Byzantium)
+		CityName=Konstantinoupolis
+		CityPopulation=4
+		BuildingType=BUILDING_PALACE
+		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_CASTLE
+		BuildingType=BUILDING_BARRACKS
+		BuildingType=BUILDING_STABLE
+		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_LIBRARY
+		BuildingType=BUILDING_BYZANTINE_HIPPODROME
+		BuildingType=BUILDING_MARKET
+		BuildingType=BUILDING_ORTHODOX_TEMPLE
+		BuildingType=BUILDING_THEODOSIAN_WALLS
+		BuildingType=BUILDING_HAGIA_SOPHIA
+		ReligionType=RELIGION_JUDAISM
+		ReligionType=RELIGION_ORTHODOXY
+		ReligionType=RELIGION_CATHOLICISM
+		Player14Culture=250, (Byzantium)
+	EndCity
 EndPlot
 BeginPlot
 	x=68,y=46
@@ -26679,31 +26898,32 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=69,y=34
-	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	BonusType=BONUS_MARBLE
+	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 EndPlot
 BeginPlot
 	x=69,y=35
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
+	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=14, (Byzantium)
 		CityName=Memphis
 		CityPopulation=2
 		BuildingType=BUILDING_PYRAMIDS
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
-		Player44Culture=10
+		Player14Culture=10, (Byzantium)
 	EndCity
-	PlotType=2
 EndPlot
 BeginPlot
 	x=69,y=36
@@ -26711,9 +26931,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=69,y=37
@@ -26755,10 +26975,10 @@ EndPlot
 BeginPlot
 	x=69,y=44
 	BonusType=BONUS_SHEEP
-	TerrainType=TERRAIN_PLAINS
-	PlotType=2
 	ImprovementType=IMPROVEMENT_PASTURE
 	RouteType=ROUTE_ROMAN_ROAD
+	TerrainType=TERRAIN_PLAINS
+	PlotType=2
 EndPlot
 BeginPlot
 	x=69,y=45
@@ -26768,9 +26988,9 @@ EndPlot
 BeginPlot
 	x=69,y=46
 	BonusType=BONUS_CLAM
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 EndPlot
 BeginPlot
 	x=69,y=47
@@ -27065,7 +27285,6 @@ BeginPlot
 	x=70,y=31
 	BonusType=BONUS_GOLD
 	TerrainType=TERRAIN_DESERT
-	BonusType=BONUS_GOLD
 	PlotType=2
 EndPlot
 BeginPlot
@@ -27082,10 +27301,10 @@ EndPlot
 BeginPlot
 	x=70,y=34
 	BonusType=BONUS_HORSE
-	TerrainType=TERRAIN_DESERT
-	PlotType=2
 	ImprovementType=IMPROVEMENT_PASTURE
 	RouteType=ROUTE_ROAD
+	TerrainType=TERRAIN_DESERT
+	PlotType=2
 EndPlot
 BeginPlot
 	x=70,y=35
@@ -27096,9 +27315,9 @@ EndPlot
 BeginPlot
 	x=70,y=36
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=70,y=37
@@ -27141,9 +27360,9 @@ BeginPlot
 	x=70,y=44
 	BonusType=BONUS_COAL
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=70,y=45
@@ -27475,9 +27694,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=71,y=36
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=71,y=37
@@ -27514,12 +27733,12 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=71,y=43
-	isWOfRiver
 	RiverNSDirection=0
-	TerrainType=TERRAIN_PLAINS
+	isWOfRiver
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	PlotType=1
 	RouteType=ROUTE_ROMAN_ROAD
+	TerrainType=TERRAIN_PLAINS
+	PlotType=1
 EndPlot
 BeginPlot
 	x=71,y=44
@@ -27822,21 +28041,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=72,y=29
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=45
+		UnitType=UNIT_SPEARMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Aksum
 		CityPopulation=2
 		BuildingType=BUILDING_ETHIOPIAN_STELE
 		ReligionType=RELIGION_ORTHODOXY
-		Player45Culture=50
+		Player45Culture=50, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
@@ -27877,9 +28097,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=72,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=72,y=38
@@ -27911,19 +28131,19 @@ BeginPlot
 	x=72,y=43
 	isNOfRiver
 	RiverWEDirection=3
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
-		CityName=Iconium
+		CityOwner=14, (Byzantium)
+		CityName=Ikonion
 		CityPopulation=2
 		BuildingType=BUILDING_MARKET
 		ReligionType=RELIGION_ORTHODOXY
-		Player44Culture=10
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -28277,40 +28497,41 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=73,y=38
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=14, (Byzantium)
 		CityName=Hierousalem
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
-		BuildingType=BUILDING_ORTHODOX_SHRINE
 		BuildingType=BUILDING_JEWISH_TEMPLE
 		BuildingType=BUILDING_JEWISH_SHRINE
+		BuildingType=BUILDING_ORTHODOX_SHRINE
 		ReligionType=RELIGION_JUDAISM
-		ReligionType=RELIGION_ORTHODOXY
-		ReligionType=RELIGION_CATHOLICISM
-		HolyCityReligionType=RELIGION_ORTHODOXY
 		HolyCityReligionType=RELIGION_JUDAISM
-		Player44Culture=10
+		ReligionType=RELIGION_ORTHODOXY
+		HolyCityReligionType=RELIGION_ORTHODOXY
+		ReligionType=RELIGION_CATHOLICISM
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
 	x=73,y=39
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=73,y=40
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=73,y=41
@@ -28321,16 +28542,16 @@ EndPlot
 BeginPlot
 	x=73,y=42
 	BonusType=BONUS_WINE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=73,y=43
 	BonusType=BONUS_WHEAT
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=73,y=44
@@ -28695,21 +28916,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=74,y=40
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=14, (Byzantium)
 		CityName=Damaskos
 		CityPopulation=3
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
-		BuildingType=BUILDING_WALLS
-		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_JUDAISM
-		Player44Culture=10
+		ReligionType=RELIGION_ORTHODOXY
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -28718,9 +28940,9 @@ BeginPlot
 	isWOfRiver
 	BonusType=BONUS_WHEAT
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=74,y=42
@@ -28741,10 +28963,10 @@ EndPlot
 BeginPlot
 	x=74,y=44
 	BonusType=BONUS_HORSE
-	TerrainType=TERRAIN_PLAINS
-	PlotType=1
 	ImprovementType=IMPROVEMENT_PASTURE
 	RouteType=ROUTE_ROAD
+	TerrainType=TERRAIN_PLAINS
+	PlotType=1
 EndPlot
 BeginPlot
 	x=74,y=45
@@ -29107,9 +29329,9 @@ BeginPlot
 	x=75,y=42
 	BonusType=BONUS_SHEEP
 	ImprovementType=IMPROVEMENT_PASTURE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=75,y=43
@@ -29118,20 +29340,21 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=75,y=44
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
-		CityName=Trapezus
+		CityOwner=14, (Byzantium)
+		CityName=Trapezounta
 		CityPopulation=3
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_HARBOR
 		ReligionType=RELIGION_ORTHODOXY
-		Player44Culture=10
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -29426,18 +29649,17 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=76,y=30
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Sana'a
 		CityPopulation=1
 		BuildingType=BUILDING_GRANARY
-		Player45Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -29509,9 +29731,9 @@ BeginPlot
 	x=76,y=42
 	RiverNSDirection=2
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=76,y=43
@@ -29872,17 +30094,18 @@ BeginPlot
 	isWOfRiver
 	BonusType=BONUS_STONE
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Tisfun
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
-		Player45Culture=10
+		Player45Culture=10, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
@@ -29890,9 +30113,9 @@ BeginPlot
 	RiverNSDirection=2
 	isWOfRiver
 	BonusType=BONUS_OIL
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=77,y=42
@@ -30251,16 +30474,15 @@ BeginPlot
 	x=78,y=39
 	RiverNSDirection=2
 	isWOfRiver
-	RiverNSDirection=2
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 EndPlot
 BeginPlot
 	x=78,y=40
-	BonusType=BONUS_SHEEP
 	isNOfRiver
 	RiverWEDirection=1
+	BonusType=BONUS_SHEEP
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 EndPlot
@@ -30272,9 +30494,9 @@ EndPlot
 BeginPlot
 	x=78,y=42
 	BonusType=BONUS_COPPER
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=78,y=43
@@ -30629,9 +30851,9 @@ EndPlot
 BeginPlot
 	x=79,y=41
 	BonusType=BONUS_WHEAT
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=79,y=42
@@ -30997,9 +31219,9 @@ EndPlot
 BeginPlot
 	x=80,y=42
 	BonusType=BONUS_OIL
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=80,y=43
@@ -31376,9 +31598,9 @@ EndPlot
 BeginPlot
 	x=81,y=42
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=81,y=43
@@ -31715,23 +31937,24 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=82,y=38
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Sirajis
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GROCER
-		BuildingType=BUILDING_ZOROASTRIAN_SHRINE
 		BuildingType=BUILDING_ZOROASTRIAN_TEMPLE
+		BuildingType=BUILDING_ZOROASTRIAN_SHRINE
 		ReligionType=RELIGION_ZOROASTRIANISM
 		HolyCityReligionType=RELIGION_ZOROASTRIANISM
-		Player45Culture=10
+		Player45Culture=10, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
@@ -31752,9 +31975,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=82,y=42
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=82,y=43
@@ -32117,31 +32340,31 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=83,y=43
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=83,y=44
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=83,y=45
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Merv
 		CityPopulation=2
 		BuildingType=BUILDING_STABLE
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=83,y=46
@@ -32492,28 +32715,29 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=84,y=41
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
+	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent)
 		CityName=Herat
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GROCER
-		Player45Culture=10
+		Player45Culture=10, (Independent)
 	EndCity
-	PlotType=2
 EndPlot
 BeginPlot
 	x=84,y=42
 	BonusType=BONUS_SHEEP
 	ImprovementType=IMPROVEMENT_PASTURE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=84,y=43
@@ -32538,9 +32762,9 @@ BeginPlot
 	x=84,y=46
 	isNOfRiver
 	RiverWEDirection=3
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=84,y=47
@@ -32923,29 +33147,29 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=85,y=46
-	TerrainType=TERRAIN_PLAINS
 	BonusType=BONUS_SILK
+	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 EndPlot
 BeginPlot
 	x=85,y=47
 	RiverNSDirection=0
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Samarkand
 		CityPopulation=3
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
-
 EndPlot
 BeginPlot
 	x=85,y=48
@@ -33323,9 +33547,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=86,y=48
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=86,y=49
@@ -33648,26 +33872,27 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=87,y=40
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
+	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Lavapuri
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		ReligionType=RELIGION_BUDDHISM
-		Player44Culture=50
+		Player44Culture=50, (Independent)
 	EndCity
-	PlotType=2
 EndPlot
 BeginPlot
 	x=87,y=41
@@ -33718,9 +33943,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=87,y=48
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=87,y=49
@@ -34014,28 +34239,29 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=88,y=34
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Mumbai
 		CityPopulation=3
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
-		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_HARBOR
+		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=50
+		Player44Culture=50, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -34056,9 +34282,9 @@ EndPlot
 BeginPlot
 	x=88,y=37
 	BonusType=BONUS_HORSE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=88,y=38
@@ -34447,9 +34673,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=89,y=38
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=89,y=39
@@ -34500,24 +34726,24 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
+	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Kashgar
 		CityPopulation=3
-		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
-		Player45Culture=40
+		Player45Culture=40, (Independent2)
 	EndCity
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
-	EndUnit
 EndPlot
 BeginPlot
 	x=89,y=47
@@ -34808,31 +35034,32 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=90,y=31
-	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
-	EndUnit
-	BeginCity
-		CityOwner=45
-		CityName=Vijayanagara
-		CityPopulation=2
-		BuildingType=BUILDING_GRANARY
-		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_WALLS
-		BuildingType=BUILDING_HINDU_TEMPLE
-		ReligionType=RELIGION_HINDUISM
-		Player45Culture=10
-	EndCity
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	BeginUnit
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
+	EndUnit
+	BeginCity
+		CityOwner=45, (Independent2)
+		CityName=Vijayanagara
+		CityPopulation=2
+		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_SMOKEHOUSE
+		BuildingType=BUILDING_HINDU_TEMPLE
+		ReligionType=RELIGION_HINDUISM
+		Player45Culture=10, (Independent2)
+	EndCity
 EndPlot
 BeginPlot
 	x=90,y=32
@@ -34869,29 +35096,30 @@ BeginPlot
 	x=90,y=37
 	isNOfRiver
 	RiverWEDirection=3
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Bhopal
 		CityPopulation=2
-		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=50
+		Player44Culture=50, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -34903,22 +35131,23 @@ EndPlot
 BeginPlot
 	x=90,y=39
 	BonusType=BONUS_IVORY
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=90,y=40
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Delhi
 		CityPopulation=8
 		BuildingType=BUILDING_STABLE
@@ -34931,7 +35160,7 @@ BeginPlot
 		BuildingType=BUILDING_HINDU_TEMPLE
 		BuildingType=BUILDING_HINDU_MONASTERY
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -34978,9 +35207,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=90,y=48
@@ -35249,30 +35478,31 @@ EndPlot
 BeginPlot
 	x=91,y=29
 	BonusType=BONUS_ALUMINUM
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Madurai
 		CityPopulation=2
-		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -35306,29 +35536,30 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=91,y=34
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Golkonda
 		CityPopulation=2
-		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player45Culture=50
+		Player45Culture=50, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
@@ -35401,10 +35632,10 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=91,y=45
+	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	ImprovementType=IMPROVEMENT_VILLAGE
 EndPlot
 BeginPlot
 	x=91,y=46
@@ -35417,9 +35648,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=91,y=48
@@ -35711,31 +35942,32 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=92,y=32
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Kanchipuram
 		CityPopulation=2
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=50
+		Player44Culture=50, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -35833,9 +36065,9 @@ BeginPlot
 	x=92,y=48
 	isNOfRiver
 	RiverWEDirection=1
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=92,y=49
@@ -36215,11 +36447,11 @@ BeginPlot
 	x=93,y=48
 	isNOfRiver
 	RiverWEDirection=1
+	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
-	ImprovementType=IMPROVEMENT_VILLAGE
 EndPlot
 BeginPlot
 	x=93,y=49
@@ -36552,19 +36784,20 @@ BeginPlot
 	x=94,y=40
 	isNOfRiver
 	RiverWEDirection=1
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Pataliputra
 		CityPopulation=8
 		BuildingType=BUILDING_STABLE
@@ -36584,7 +36817,7 @@ BeginPlot
 		HolyCityReligionType=RELIGION_HINDUISM
 		ReligionType=RELIGION_BUDDHISM
 		HolyCityReligionType=RELIGION_BUDDHISM
-		Player45Culture=50
+		Player45Culture=50, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
@@ -36625,9 +36858,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=94,y=48
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=94,y=49
@@ -36924,31 +37157,32 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=95,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Kolkata
 		CityPopulation=2
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player45Culture=50
+		Player45Culture=50, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
@@ -37011,26 +37245,27 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=95,y=47
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
+	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Dunhuang
 		CityPopulation=3
-		ReligionType=RELIGION_BUDDHISM
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
-		Player44Culture=20
+		ReligionType=RELIGION_BUDDHISM
+		Player44Culture=20, (Independent)
 	EndCity
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
-	EndUnit
 EndPlot
 BeginPlot
 	x=95,y=48
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=95,y=49
@@ -37391,17 +37626,17 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=96,y=47
+	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
-	ImprovementType=IMPROVEMENT_VILLAGE
 	PlotType=2
 EndPlot
 BeginPlot
 	x=96,y=48
 	BonusType=BONUS_COTTON
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=96,y=49
@@ -37757,9 +37992,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=97,y=47
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=97,y=48
@@ -38064,21 +38299,21 @@ BeginPlot
 	x=98,y=36
 	RiverNSDirection=2
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Pagan
 		CityPopulation=4
 		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_SHWEDAGON_PAYA
 		ReligionType=RELIGION_BUDDHISM
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
-
 EndPlot
 BeginPlot
 	x=98,y=37
@@ -38158,9 +38393,9 @@ EndPlot
 BeginPlot
 	x=98,y=47
 	BonusType=BONUS_OIL
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=98,y=48
@@ -38504,9 +38739,19 @@ BeginPlot
 	x=99,y=41
 	RiverNSDirection=2
 	isWOfRiver
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+(	RouteType=ROUTE_ROAD)
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+(	BeginUnit)
+(		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent))
+(	EndUnit)
+(	BeginCity)
+(		CityOwner=44, (Independent))
+(		CityName=Chengdu)
+(		CityPopulation=2)
+(		BuildingType=BUILDING_GRANARY)
+(		ReligionType=RELIGION_CONFUCIANISM)
+(	EndCity)
 EndPlot
 BeginPlot
 	x=99,y=42
@@ -38518,8 +38763,8 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	BonusType=BONUS_PIG
-	TerrainType=TERRAIN_GRASS
 	ImprovementType=IMPROVEMENT_PASTURE
+	TerrainType=TERRAIN_GRASS
 	PlotType=1
 EndPlot
 BeginPlot
@@ -38538,9 +38783,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=99,y=47
@@ -38928,23 +39173,57 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=100,y=44
-	FeatureType=FEATURE_FOREST, FeatureVariety=1
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+(	BeginUnit)
+(		UnitType=UNIT_HORSE_ARCHER, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_CHINESE_CHOKONU, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_CHINESE_CHOKONU, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_SWORDSMAN, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_SWORDSMAN, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_SPEARMAN, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_ARCHER, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_WORKER, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_WORKER, UnitOwner=1, (China))
+(	EndUnit)
 	BeginCity
-		CityOwner=45
-		CityName=Chang'an
-		CityPopulation=1
-		Player45Culture=3000
+		CityOwner=45, (China)
+		CityName=Chang'an, (Xi'an)
+		CityPopulation=1, (4)
+(		BuildingType=BUILDING_PALACE)
+(		BuildingType=BUILDING_BARRACKS)
+(		BuildingType=BUILDING_FORGE)
+(		BuildingType=BUILDING_CHINESE_TAIXUE)
+(		BuildingType=BUILDING_CONFUCIAN_TEMPLE)
+(		ReligionType=RELIGION_CONFUCIANISM)
+(		ReligionType=RELIGION_TAOISM)
+		Player45Culture=3000, (100)
 	EndCity
 EndPlot
 BeginPlot
 	x=100,y=45
 	BonusType=BONUS_IRON
 	ImprovementType=IMPROVEMENT_MINE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=100,y=46
@@ -39322,15 +39601,15 @@ BeginPlot
 	x=101,y=43
 	BonusType=BONUS_COAL
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=101,y=44
 	BonusType=BONUS_WHEAT
-	TerrainType=TERRAIN_GRASS
 	ImprovementType=IMPROVEMENT_FARM
+	TerrainType=TERRAIN_GRASS
 	PlotType=2
 EndPlot
 BeginPlot
@@ -39704,7 +39983,7 @@ BeginPlot
 	x=102,y=41
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
-	BeginCity
+	BeginCity, (Removed after game start)
 		CityOwner=45
 		CityName=Guiyang
 		CityPopulation=1
@@ -39732,9 +40011,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=102,y=44
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=102,y=45
@@ -39753,32 +40032,31 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=102,y=47
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=45
+		UnitType=UNIT_SPEARMAN, UnitOwner=45, (China)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=45
+		UnitType=UNIT_SPEARMAN, UnitOwner=45, (China)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (China)
 		CityName=Beijing
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_LIBRARY
+		BuildingType=BUILDING_CHINESE_TAIXUE
 		BuildingType=BUILDING_MARKET
+		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		BuildingType=BUILDING_TAOIST_TEMPLE
-		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_GREAT_WALL
 		ReligionType=RELIGION_BUDDHISM
-		ReligionType=RELIGION_TAOISM
 		ReligionType=RELIGION_CONFUCIANISM
-		HolyCityReligionType=RELIGION_TAOISM
-		HolyCityReligionType=RELIGION_CONFUCIANISM
-		Player45Culture=100
+		ReligionType=RELIGION_TAOISM
+		Player45Culture=100, (20)
 	EndCity
 EndPlot
 BeginPlot
@@ -40147,27 +40425,26 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=103,y=44
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (China)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (China)
 		CityName=Kaifeng
 		CityPopulation=2
-		BuildingType=BUILDING_LIBRARY
-		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_CHINESE_TAIXUE
+		BuildingType=BUILDING_MARKET
+		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		BuildingType=BUILDING_TAOIST_TEMPLE
-		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		ReligionType=RELIGION_BUDDHISM
-		ReligionType=RELIGION_TAOISM
 		ReligionType=RELIGION_CONFUCIANISM
-		HolyCityReligionType=RELIGION_TAOISM
-		HolyCityReligionType=RELIGION_CONFUCIANISM
-		Player45Culture=100
+		ReligionType=RELIGION_TAOISM
+		Player45Culture=100, (20)
 	EndCity
 EndPlot
 BeginPlot
@@ -40915,22 +41192,23 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=105,y=39
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=45
+		UnitType=UNIT_SPEARMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Guangzhou
 		CityPopulation=3
-		BuildingType=BUILDING_LIBRARY
-		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
+		BuildingType=BUILDING_LIBRARY
+		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		ReligionType=RELIGION_BUDDHISM
-		Player45Culture=100
+		Player45Culture=100, (0)
 	EndCity
 EndPlot
 BeginPlot
@@ -40961,18 +41239,19 @@ BeginPlot
 	x=105,y=43
 	isNOfRiver
 	RiverWEDirection=1
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (China)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (China)
 		CityName=Nanjing
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_LIBRARY
+		BuildingType=BUILDING_CHINESE_TAIXUE
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		BuildingType=BUILDING_CONFUCIAN_MONASTERY
@@ -40981,10 +41260,10 @@ BeginPlot
 		BuildingType=BUILDING_TAOIST_MONASTERY
 		BuildingType=BUILDING_TAOIST_SHRINE
 		ReligionType=RELIGION_CONFUCIANISM
-		ReligionType=RELIGION_TAOISM
 		HolyCityReligionType=RELIGION_CONFUCIANISM
+		ReligionType=RELIGION_TAOISM
 		HolyCityReligionType=RELIGION_TAOISM
-		Player45Culture=100
+		Player45Culture=100, (20)
 	EndCity
 EndPlot
 BeginPlot
@@ -41016,8 +41295,27 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=105,y=49
+(	RouteType=ROUTE_ROAD)
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+(	BeginUnit)
+(		UnitType=UNIT_ARCHER, UnitOwner=49, (Barbarian))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_WARRIOR, UnitOwner=49, (Barbarian))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_WARRIOR, UnitOwner=49, (Barbarian))
+(	EndUnit)
+(	BeginCity)
+(		CityOwner=49, (Barbarian))
+(		CityName=Simiyan hoton)
+(		CityPopulation=2)
+(		BuildingType=BUILDING_WALLS)
+(		BuildingType=BUILDING_GRANARY)
+(		BuildingType=BUILDING_CONFUCIAN_TEMPLE)
+(		ReligionType=RELIGION_CONFUCIANISM)
+(	EndCity)
 EndPlot
 BeginPlot
 	x=105,y=50
@@ -41366,12 +41664,12 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=106,y=43
-	BonusType=BONUS_RICE
-	ImprovementType=IMPROVEMENT_FARM
+	RiverNSDirection=0
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
-	RiverNSDirection=0
+	BonusType=BONUS_RICE
+	ImprovementType=IMPROVEMENT_FARM
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 EndPlot
@@ -41733,11 +42031,11 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=107,y=42
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Hangzhou
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -41746,7 +42044,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		ReligionType=RELIGION_BUDDHISM
 		ReligionType=RELIGION_CONFUCIANISM
-		Player45Culture=100
+		Player45Culture=100, (0)
 	EndCity
 EndPlot
 BeginPlot
@@ -42538,6 +42836,42 @@ BeginPlot
 	x=109,y=46
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+(	BeginUnit)
+(		UnitType=UNIT_HEAVY_SWORDSMAN, UnitOwner=12, (Korea)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_HEAVY_SWORDSMAN, UnitOwner=12, (Korea)) (AI only)
+(	EndUnit)
+	BeginUnit
+		UnitType=UNIT_HORSE_ARCHER, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_AXEMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_AXEMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_AXEMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CONFUCIAN_MISSIONARY, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BUDDHIST_MISSIONARY, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=12, (Korea)
+	EndUnit
 EndPlot
 BeginPlot
 	x=109,y=47
@@ -43649,6 +43983,12 @@ BeginPlot
 	BonusType=BONUS_FISH
 	TerrainType=TERRAIN_COAST
 	PlotType=3
+	BeginUnit
+		UnitType=UNIT_WORK_BOAT, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_WORK_BOAT, UnitOwner=15, (Japan)
+	EndUnit
 EndPlot
 BeginPlot
 	x=112,y=47
@@ -44011,6 +44351,51 @@ BeginPlot
 	x=113,y=45
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+(	BeginUnit)
+(		UnitType=UNIT_JAPANESE_SAMURAI, UnitOwner=15, (Japan)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_JAPANESE_SAMURAI, UnitOwner=15, (Japan)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_JAPANESE_SAMURAI, UnitOwner=15, (Japan)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_CROSSBOWMAN, UnitOwner=15, (Japan)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_CROSSBOWMAN, UnitOwner=15, (Japan)) (AI only)
+(	EndUnit)
+	BeginUnit
+		UnitType=UNIT_SWORDSMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SWORDSMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BUDDHIST_MISSIONARY, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BUDDHIST_MISSIONARY, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BUDDHIST_MISSIONARY, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=15, (Japan)
+	EndUnit
 EndPlot
 BeginPlot
 	x=113,y=46

--- a/PrivateMaps/RFC 600 AD.CivBeyondSwordWBSave
+++ b/PrivateMaps/RFC 600 AD.CivBeyondSwordWBSave
@@ -7206,7 +7206,7 @@ EndPlot
 BeginPlot
 	x=17,y=65
 	TerrainType=TERRAIN_SNOW
-	PlotType=2
+	PlotType=3
 EndPlot
 BeginPlot
 	x=17,y=66
@@ -8892,18 +8892,18 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=22,y=35
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MAYAN_HOLKAN, UnitOwner=46, (Native)
+		UnitType=UNIT_MAYAN_HOLKAN, UnitOwner=46
 	EndUnit
 	BeginCity
-		CityOwner=46, (Native)
+		CityOwner=46
 		CityName=Yax Mutal
 		CityPopulation=2
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_MAYAN_BALL_COURT
+		Player46Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -9298,22 +9298,21 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=23,y=37
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MAYAN_HOLKAN, UnitOwner=46, (Native)
+		UnitType=UNIT_MAYAN_HOLKAN, UnitOwner=46
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_WORKER, UnitOwner=46, (Native)
+		UnitType=UNIT_WORKER, UnitOwner=46
 	EndUnit
 	BeginCity
-		CityOwner=46, (Native)
+		CityOwner=46
 		CityName=Chich'en Itz&#225;
 		CityPopulation=2
 		BuildingType=BUILDING_MAYAN_BALL_COURT
 		BuildingType=BUILDING_TEMPLE_OF_KUKULKAN
-		Player46Culture=10, (Native)
+		Player46Culture=10
 	EndCity
 EndPlot
 BeginPlot
@@ -19605,19 +19604,19 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=51,y=37
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Marrakus
 		CityPopulation=2
+		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_HARBOR
+		Player44Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -20048,9 +20047,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=52,y=47
@@ -20429,26 +20428,26 @@ EndPlot
 BeginPlot
 	x=53,y=47
 	BonusType=BONUS_WINE
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=53,y=48
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Burdigala
 		CityPopulation=3
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
 		ReligionType=RELIGION_CATHOLICISM
+		Player44Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -20789,17 +20788,17 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=54,y=42
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=54,y=43
 	BonusType=BONUS_SILVER
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=54,y=44
@@ -20827,9 +20826,9 @@ BeginPlot
 	RiverNSDirection=0
 	isWOfRiver
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=54,y=48
@@ -21182,27 +21181,28 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=55,y=44
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Barcelona
 		CityPopulation=2
-		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_HARBOR
+		BuildingType=BUILDING_GRANARY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
+		Player45Culture=1
 	EndCity
 EndPlot
 BeginPlot
 	x=55,y=45
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=55,y=46
@@ -21212,9 +21212,9 @@ EndPlot
 BeginPlot
 	x=55,y=47
 	BonusType=BONUS_WHEAT
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=55,y=48
@@ -21572,22 +21572,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=56,y=46
-	RiverNSDirection=2
 	isWOfRiver
-	RouteType=ROUTE_ROAD
+	RiverNSDirection=2
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Massilia
 		CityPopulation=3
-		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_HARBOR
+		BuildingType=BUILDING_GRANARY
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
+		Player44Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -21596,25 +21596,25 @@ BeginPlot
 	isWOfRiver
 	BonusType=BONUS_ALUMINUM
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=56,y=48
 	RiverNSDirection=2
 	isWOfRiver
 	BonusType=BONUS_WINE
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=56,y=49
 	BonusType=BONUS_PIG
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=56,y=50
@@ -21918,9 +21918,9 @@ BeginPlot
 	RiverWEDirection=1
 	isWOfRiver
 	BonusType=BONUS_SHEEP
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=57,y=40
@@ -21955,9 +21955,9 @@ EndPlot
 BeginPlot
 	x=57,y=46
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=57,y=47
@@ -22271,22 +22271,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=58,y=37
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=58,y=38
 	BonusType=BONUS_STONE
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=58,y=39
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=58,y=40
@@ -22322,9 +22322,9 @@ EndPlot
 BeginPlot
 	x=58,y=46
 	BonusType=BONUS_STONE
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=58,y=47
@@ -22644,9 +22644,9 @@ EndPlot
 BeginPlot
 	x=59,y=37
 	BonusType=BONUS_WHEAT
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=59,y=38
@@ -22695,9 +22695,9 @@ EndPlot
 BeginPlot
 	x=59,y=46
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=59,y=47
@@ -23027,20 +23027,19 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=60,y=37
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_ARCHER, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent)
+		UnitType=UNIT_SPEARMAN, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Tripolis
 		CityPopulation=2
-		Player44Culture=10, (Independent)
+		Player44Culture=10
 	EndCity
 EndPlot
 BeginPlot
@@ -23078,62 +23077,61 @@ BeginPlot
 	x=60,y=44
 	RiverNSDirection=2
 	isWOfRiver
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_PIKEMAN, UnitOwner=45
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_PIKEMAN, UnitOwner=45
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CATHOLIC_MISSIONARY, UnitOwner=45, (Independent2)
+		UnitType=UNIT_CATHOLIC_MISSIONARY, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_WORKER, UnitOwner=45, (Independent2)
+		UnitType=UNIT_WORKER, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Roma
 		CityPopulation=4
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_BARRACKS
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_ROMAN_FORUM
+		BuildingType=BUILDING_COLOSSEUM
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		BuildingType=BUILDING_CATHOLIC_SHRINE
-		BuildingType=BUILDING_COLOSSEUM
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
 		HolyCityReligionType=RELIGION_CATHOLICISM
-		Player45Culture=100, (Independent2)
+		Player45Culture=100
 	EndCity
 EndPlot
 BeginPlot
 	x=60,y=45
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=60,y=46
@@ -23147,9 +23145,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	BonusType=BONUS_WHEAT
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=60,y=48
@@ -23208,12 +23206,6 @@ BeginPlot
 	x=60,y=56
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-(	BeginUnit)
-(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (AI only)
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)) (AI only)
-(	EndUnit)
 EndPlot
 BeginPlot
 	x=60,y=57
@@ -23224,66 +23216,11 @@ BeginPlot
 	x=60,y=58
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	BeginUnit
-		UnitType=UNIT_GALLEY, UnitOwner=16, (Vikings)
-		UnitAIType=UNITAI_SETTLER_SEA
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_GALLEY, UnitOwner=16, (Vikings)
-		UnitAIType=UNITAI_EXPLORE_SEA
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_GALLEY, UnitOwner=16, (Vikings)
-		UnitAIType=UNITAI_EXPLORE_SEA
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_WORK_BOAT, UnitOwner=16, (Vikings)
-	EndUnit
-(	BeginUnit)
-(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (Human only)
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)) (Human only)
-(	EndUnit)
 EndPlot
 BeginPlot
 	x=60,y=59
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-(	BeginUnit)
-(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (Human only)
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (Human only)
-(	EndUnit)
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SWORDSMAN, UnitOwner=16, (Vikings)
-		UnitAIType=UNITAI_ATTACK_CITY
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SWORDSMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_AXEMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_AXEMAN, UnitOwner=16, (Vikings)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SCOUT, UnitOwner=16, (Vikings)
-	EndUnit
-(	BeginUnit)
-(		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)) (Human only)
-(	EndUnit)
-	BeginUnit
-		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)
-	EndUnit
 EndPlot
 BeginPlot
 	x=60,y=60
@@ -23530,9 +23467,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=61,y=37
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=61,y=38
@@ -23562,9 +23499,9 @@ EndPlot
 BeginPlot
 	x=61,y=43
 	BonusType=BONUS_PIG
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=61,y=44
@@ -23587,42 +23524,43 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=61,y=47
-	RouteType=ROUTE_ROAD
+	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_PIKEMAN, UnitOwner=44
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Venetia
 		CityPopulation=2
-		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_HARBOR
+		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_MARKET
 		ReligionType=RELIGION_CATHOLICISM
+		Player44Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -23945,9 +23883,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=62,y=36
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=62,y=37
@@ -23978,19 +23916,20 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=62,y=42
-	RouteType=ROUTE_ROAD
+	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
+	RouteType=ROUTE_ROAD
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+		UnitType=UNIT_ARCHER, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=14, (Byzantium)
-		CityName=Neapolis
+		CityOwner=44
+		CityName=Napoli
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
 		ReligionType=RELIGION_CATHOLICISM
-		Player14Culture=10, (Byzantium)
+		Player44Culture=10
 	EndCity
 EndPlot
 BeginPlot
@@ -24029,19 +23968,19 @@ BeginPlot
 	x=62,y=49
 	RiverNSDirection=2
 	isWOfRiver
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Vindobona
 		CityPopulation=1
 		BuildingType=BUILDING_GRANARY
+		Player45Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -24355,9 +24294,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=63,y=36
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=63,y=37
@@ -24387,9 +24326,9 @@ EndPlot
 BeginPlot
 	x=63,y=42
 	BonusType=BONUS_SHEEP
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=63,y=43
@@ -24493,12 +24432,6 @@ BeginPlot
 	RiverWEDirection=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-(	BeginUnit)
-(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (AI only)
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)) (AI only)
-(	EndUnit)
 EndPlot
 BeginPlot
 	x=63,y=60
@@ -24755,17 +24688,16 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=64,y=36
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=44, (Independent)
+		UnitType=UNIT_SPEARMAN, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Hesperides
 		CityPopulation=2
-		Player44Culture=10, (Independent)
+		Player44Culture=10
 	EndCity
 EndPlot
 BeginPlot
@@ -25174,9 +25106,9 @@ EndPlot
 BeginPlot
 	x=65,y=37
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=65,y=38
@@ -25206,9 +25138,9 @@ EndPlot
 BeginPlot
 	x=65,y=43
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=65,y=44
@@ -25218,19 +25150,19 @@ EndPlot
 BeginPlot
 	x=65,y=45
 	BonusType=BONUS_ALUMINUM
-	RouteType=ROUTE_ROMAN_ROAD
+	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=14, (Byzantium)
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=14, (Byzantium)
-		CityName=Singidunon
+		CityOwner=44
+		CityName=Belgrad
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
 		ReligionType=RELIGION_ORTHODOXY
-		Player14Culture=10, (Byzantium)
+		Player44Culture=10
 	EndCity
 EndPlot
 BeginPlot
@@ -25596,9 +25528,9 @@ BeginPlot
 	x=66,y=37
 	BonusType=BONUS_DYE
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=66,y=38
@@ -25626,10 +25558,10 @@ EndPlot
 BeginPlot
 	x=66,y=42
 	BonusType=BONUS_IRON
-	ImprovementType=IMPROVEMENT_MINE
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
+	ImprovementType=IMPROVEMENT_MINE
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=66,y=43
@@ -25640,9 +25572,9 @@ BeginPlot
 	x=66,y=44
 	BonusType=BONUS_SHEEP
 	ImprovementType=IMPROVEMENT_PASTURE
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=66,y=45
@@ -26006,15 +25938,14 @@ BeginPlot
 	x=67,y=36
 	RiverNSDirection=0
 	isWOfRiver
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
+		UnitType=UNIT_SPEARMAN, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=14, (Byzantium)
-		CityName=Alexandreia
+		CityOwner=44
+		CityName=Alexandria
 		CityPopulation=3
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_GREAT_LIGHTHOUSE
@@ -26022,7 +25953,7 @@ BeginPlot
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_CATHOLICISM
-		Player14Culture=10, (Byzantium)
+		Player44Culture=10
 	EndCity
 EndPlot
 BeginPlot
@@ -26048,30 +25979,30 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=67,y=41
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
+		UnitType=UNIT_WORKER, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+		UnitType=UNIT_ARCHER, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_WORKER, UnitOwner=14, (Byzantium)
+		UnitType=UNIT_SPEARMAN, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=14, (Byzantium)
-		CityName=Athinai
+		CityOwner=44
+		CityName=Athenae
 		CityPopulation=3
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_PAGAN_TEMPLE
 		BuildingType=BUILDING_LIBRARY
-		BuildingType=BUILDING_BYZANTINE_HIPPODROME
-		BuildingType=BUILDING_PARTHENON
+		BuildingType=BUILDING_THEATRE
+		BuildingType=BUILDING_GREEK_ODEON
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
-		Player14Culture=50, (Byzantium)
+		BuildingType=BUILDING_PARTHENON
+		Player44Culture=50
 	EndCity
 EndPlot
 BeginPlot
@@ -26088,9 +26019,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=67,y=44
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=67,y=45
@@ -26458,9 +26389,9 @@ BeginPlot
 	RiverWEDirection=0
 	isWOfRiver
 	BonusType=BONUS_WHEAT
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=68,y=37
@@ -26506,72 +26437,11 @@ BeginPlot
 	BonusType=BONUS_FISH
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	BeginUnit
-		UnitType=UNIT_TRIREME, UnitOwner=14, (Byzantium)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_TRIREME, UnitOwner=14, (Byzantium)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_GALLEY, UnitOwner=14, (Byzantium)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_GALLEY, UnitOwner=14, (Byzantium)
-	EndUnit
 EndPlot
 BeginPlot
 	x=68,y=45
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_BYZANTINE_CATAPHRACT, UnitOwner=14, (Byzantium)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_WORKER, UnitOwner=14, (Byzantium)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_WORKER, UnitOwner=14, (Byzantium)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_WORKER, UnitOwner=14, (Byzantium)
-	EndUnit
-	BeginCity
-		CityOwner=14, (Byzantium)
-		CityName=Konstantinoupolis
-		CityPopulation=4
-		BuildingType=BUILDING_PALACE
-		BuildingType=BUILDING_WALLS
-		BuildingType=BUILDING_CASTLE
-		BuildingType=BUILDING_BARRACKS
-		BuildingType=BUILDING_STABLE
-		BuildingType=BUILDING_GRANARY
-		BuildingType=BUILDING_LIBRARY
-		BuildingType=BUILDING_BYZANTINE_HIPPODROME
-		BuildingType=BUILDING_MARKET
-		BuildingType=BUILDING_ORTHODOX_TEMPLE
-		BuildingType=BUILDING_THEODOSIAN_WALLS
-		BuildingType=BUILDING_HAGIA_SOPHIA
-		ReligionType=RELIGION_JUDAISM
-		ReligionType=RELIGION_ORTHODOXY
-		ReligionType=RELIGION_CATHOLICISM
-		Player14Culture=250, (Byzantium)
-	EndCity
 EndPlot
 BeginPlot
 	x=68,y=46
@@ -26898,32 +26768,31 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=69,y=34
-	BonusType=BONUS_MARBLE
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
+	BonusType=BONUS_MARBLE
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 EndPlot
 BeginPlot
 	x=69,y=35
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
-	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
+		UnitType=UNIT_ARCHER, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+		UnitType=UNIT_SPEARMAN, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=14, (Byzantium)
+		CityOwner=44
 		CityName=Memphis
 		CityPopulation=2
 		BuildingType=BUILDING_PYRAMIDS
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
-		Player14Culture=10, (Byzantium)
+		Player44Culture=10
 	EndCity
+	PlotType=2
 EndPlot
 BeginPlot
 	x=69,y=36
@@ -26931,9 +26800,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=69,y=37
@@ -26975,10 +26844,10 @@ EndPlot
 BeginPlot
 	x=69,y=44
 	BonusType=BONUS_SHEEP
-	ImprovementType=IMPROVEMENT_PASTURE
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	ImprovementType=IMPROVEMENT_PASTURE
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=69,y=45
@@ -26988,9 +26857,9 @@ EndPlot
 BeginPlot
 	x=69,y=46
 	BonusType=BONUS_CLAM
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 EndPlot
 BeginPlot
 	x=69,y=47
@@ -27285,6 +27154,7 @@ BeginPlot
 	x=70,y=31
 	BonusType=BONUS_GOLD
 	TerrainType=TERRAIN_DESERT
+	BonusType=BONUS_GOLD
 	PlotType=2
 EndPlot
 BeginPlot
@@ -27301,10 +27171,10 @@ EndPlot
 BeginPlot
 	x=70,y=34
 	BonusType=BONUS_HORSE
-	ImprovementType=IMPROVEMENT_PASTURE
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	ImprovementType=IMPROVEMENT_PASTURE
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=70,y=35
@@ -27315,9 +27185,9 @@ EndPlot
 BeginPlot
 	x=70,y=36
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=70,y=37
@@ -27360,9 +27230,9 @@ BeginPlot
 	x=70,y=44
 	BonusType=BONUS_COAL
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=70,y=45
@@ -27694,9 +27564,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=71,y=36
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=71,y=37
@@ -27733,12 +27603,12 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=71,y=43
-	RiverNSDirection=0
 	isWOfRiver
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROMAN_ROAD
+	RiverNSDirection=0
 	TerrainType=TERRAIN_PLAINS
+	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	PlotType=1
+	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=71,y=44
@@ -28041,22 +27911,21 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=72,y=29
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_SPEARMAN, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
+		UnitType=UNIT_ARCHER, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Aksum
 		CityPopulation=2
 		BuildingType=BUILDING_ETHIOPIAN_STELE
 		ReligionType=RELIGION_ORTHODOXY
-		Player45Culture=50, (Independent2)
+		Player45Culture=50
 	EndCity
 EndPlot
 BeginPlot
@@ -28097,9 +27966,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=72,y=37
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=72,y=38
@@ -28131,19 +28000,19 @@ BeginPlot
 	x=72,y=43
 	isNOfRiver
 	RiverWEDirection=3
-	RouteType=ROUTE_ROAD
+	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+		UnitType=UNIT_ARCHER, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=14, (Byzantium)
-		CityName=Ikonion
+		CityOwner=44
+		CityName=Iconium
 		CityPopulation=2
 		BuildingType=BUILDING_MARKET
 		ReligionType=RELIGION_ORTHODOXY
-		Player14Culture=10, (Byzantium)
+		Player44Culture=10
 	EndCity
 EndPlot
 BeginPlot
@@ -28497,41 +28366,40 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=73,y=38
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+		UnitType=UNIT_ARCHER, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=14, (Byzantium)
+		CityOwner=44
 		CityName=Hierousalem
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_ORTHODOX_SHRINE
 		BuildingType=BUILDING_JEWISH_TEMPLE
 		BuildingType=BUILDING_JEWISH_SHRINE
-		BuildingType=BUILDING_ORTHODOX_SHRINE
 		ReligionType=RELIGION_JUDAISM
-		HolyCityReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
-		HolyCityReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_CATHOLICISM
-		Player14Culture=10, (Byzantium)
+		HolyCityReligionType=RELIGION_ORTHODOXY
+		HolyCityReligionType=RELIGION_JUDAISM
+		Player44Culture=10
 	EndCity
 EndPlot
 BeginPlot
 	x=73,y=39
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=73,y=40
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=73,y=41
@@ -28542,16 +28410,16 @@ EndPlot
 BeginPlot
 	x=73,y=42
 	BonusType=BONUS_WINE
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=73,y=43
 	BonusType=BONUS_WHEAT
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=73,y=44
@@ -28916,22 +28784,21 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=74,y=40
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+		UnitType=UNIT_ARCHER, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=14, (Byzantium)
+		CityOwner=44
 		CityName=Damaskos
 		CityPopulation=3
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
-		ReligionType=RELIGION_JUDAISM
+		BuildingType=BUILDING_WALLS
 		ReligionType=RELIGION_ORTHODOXY
-		Player14Culture=10, (Byzantium)
+		ReligionType=RELIGION_JUDAISM
+		Player44Culture=10
 	EndCity
 EndPlot
 BeginPlot
@@ -28940,9 +28807,9 @@ BeginPlot
 	isWOfRiver
 	BonusType=BONUS_WHEAT
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=74,y=42
@@ -28963,10 +28830,10 @@ EndPlot
 BeginPlot
 	x=74,y=44
 	BonusType=BONUS_HORSE
-	ImprovementType=IMPROVEMENT_PASTURE
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
+	ImprovementType=IMPROVEMENT_PASTURE
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=74,y=45
@@ -29329,9 +29196,9 @@ BeginPlot
 	x=75,y=42
 	BonusType=BONUS_SHEEP
 	ImprovementType=IMPROVEMENT_PASTURE
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=75,y=43
@@ -29340,21 +29207,20 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=75,y=44
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+		UnitType=UNIT_ARCHER, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=14, (Byzantium)
-		CityName=Trapezounta
+		CityOwner=44
+		CityName=Trapezus
 		CityPopulation=3
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_HARBOR
 		ReligionType=RELIGION_ORTHODOXY
-		Player14Culture=10, (Byzantium)
+		Player44Culture=10
 	EndCity
 EndPlot
 BeginPlot
@@ -29649,17 +29515,18 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=76,y=30
-	RouteType=ROUTE_ROAD
+	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
+		UnitType=UNIT_ARCHER, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Sana'a
 		CityPopulation=1
 		BuildingType=BUILDING_GRANARY
+		Player45Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -29731,9 +29598,9 @@ BeginPlot
 	x=76,y=42
 	RiverNSDirection=2
 	isWOfRiver
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=76,y=43
@@ -30094,18 +29961,17 @@ BeginPlot
 	isWOfRiver
 	BonusType=BONUS_STONE
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
+		UnitType=UNIT_ARCHER, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Tisfun
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
-		Player45Culture=10, (Independent2)
+		Player45Culture=10
 	EndCity
 EndPlot
 BeginPlot
@@ -30113,9 +29979,9 @@ BeginPlot
 	RiverNSDirection=2
 	isWOfRiver
 	BonusType=BONUS_OIL
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=77,y=42
@@ -30474,15 +30340,16 @@ BeginPlot
 	x=78,y=39
 	RiverNSDirection=2
 	isWOfRiver
+	RiverNSDirection=2
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 EndPlot
 BeginPlot
 	x=78,y=40
+	BonusType=BONUS_SHEEP
 	isNOfRiver
 	RiverWEDirection=1
-	BonusType=BONUS_SHEEP
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 EndPlot
@@ -30494,9 +30361,9 @@ EndPlot
 BeginPlot
 	x=78,y=42
 	BonusType=BONUS_COPPER
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=78,y=43
@@ -30851,9 +30718,9 @@ EndPlot
 BeginPlot
 	x=79,y=41
 	BonusType=BONUS_WHEAT
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=79,y=42
@@ -31219,9 +31086,9 @@ EndPlot
 BeginPlot
 	x=80,y=42
 	BonusType=BONUS_OIL
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=80,y=43
@@ -31598,9 +31465,9 @@ EndPlot
 BeginPlot
 	x=81,y=42
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=81,y=43
@@ -31937,24 +31804,23 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=82,y=38
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
+		UnitType=UNIT_ARCHER, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Sirajis
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GROCER
-		BuildingType=BUILDING_ZOROASTRIAN_TEMPLE
 		BuildingType=BUILDING_ZOROASTRIAN_SHRINE
+		BuildingType=BUILDING_ZOROASTRIAN_TEMPLE
 		ReligionType=RELIGION_ZOROASTRIANISM
 		HolyCityReligionType=RELIGION_ZOROASTRIANISM
-		Player45Culture=10, (Independent2)
+		Player45Culture=10
 	EndCity
 EndPlot
 BeginPlot
@@ -31975,9 +31841,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=82,y=42
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=82,y=43
@@ -32340,31 +32206,31 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=83,y=43
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=83,y=44
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=83,y=45
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent)
+		UnitType=UNIT_ARCHER, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Merv
 		CityPopulation=2
 		BuildingType=BUILDING_STABLE
-		Player44Culture=10, (Independent)
+		Player44Culture=10
 	EndCity
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=83,y=46
@@ -32715,29 +32581,28 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=84,y=41
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
-	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent)
+		UnitType=UNIT_ARCHER, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent)
+		CityOwner=45
 		CityName=Herat
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GROCER
-		Player45Culture=10, (Independent)
+		Player45Culture=10
 	EndCity
+	PlotType=2
 EndPlot
 BeginPlot
 	x=84,y=42
 	BonusType=BONUS_SHEEP
 	ImprovementType=IMPROVEMENT_PASTURE
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=84,y=43
@@ -32762,9 +32627,9 @@ BeginPlot
 	x=84,y=46
 	isNOfRiver
 	RiverWEDirection=3
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=84,y=47
@@ -33147,29 +33012,29 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=85,y=46
-	BonusType=BONUS_SILK
 	TerrainType=TERRAIN_PLAINS
+	BonusType=BONUS_SILK
 	PlotType=2
 EndPlot
 BeginPlot
 	x=85,y=47
 	RiverNSDirection=0
 	isWOfRiver
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent)
+		UnitType=UNIT_ARCHER, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Samarkand
 		CityPopulation=3
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
-		Player44Culture=10, (Independent)
+		Player44Culture=10
 	EndCity
+
 EndPlot
 BeginPlot
 	x=85,y=48
@@ -33547,9 +33412,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=86,y=48
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=86,y=49
@@ -33872,27 +33737,26 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=87,y=40
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
-	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Lavapuri
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		ReligionType=RELIGION_BUDDHISM
-		Player44Culture=50, (Independent)
+		Player44Culture=50
 	EndCity
+	PlotType=2
 EndPlot
 BeginPlot
 	x=87,y=41
@@ -33943,9 +33807,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=87,y=48
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=87,y=49
@@ -34239,29 +34103,28 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=88,y=34
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Mumbai
 		CityPopulation=3
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
-		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_MARKET
+		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=50, (Independent)
+		Player44Culture=50
 	EndCity
 EndPlot
 BeginPlot
@@ -34282,9 +34145,9 @@ EndPlot
 BeginPlot
 	x=88,y=37
 	BonusType=BONUS_HORSE
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=88,y=38
@@ -34673,9 +34536,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=89,y=38
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=89,y=39
@@ -34726,24 +34589,24 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
-	EndUnit
+	RouteType=ROUTE_ROAD
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Kashgar
 		CityPopulation=3
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_MARKET
-		Player45Culture=40, (Independent2)
+		Player45Culture=40
 	EndCity
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
+	EndUnit
 EndPlot
 BeginPlot
 	x=89,y=47
@@ -35034,32 +34897,31 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=90,y=31
-	RouteType=ROUTE_ROAD
-	TerrainType=TERRAIN_GRASS
-	PlotType=1
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Vijayanagara
 		CityPopulation=2
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player45Culture=10, (Independent2)
+		Player45Culture=10
 	EndCity
+	TerrainType=TERRAIN_GRASS
+	PlotType=1
 EndPlot
 BeginPlot
 	x=90,y=32
@@ -35096,30 +34958,29 @@ BeginPlot
 	x=90,y=37
 	isNOfRiver
 	RiverWEDirection=3
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Bhopal
 		CityPopulation=2
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=50, (Independent)
+		Player44Culture=50
 	EndCity
 EndPlot
 BeginPlot
@@ -35131,23 +34992,22 @@ EndPlot
 BeginPlot
 	x=90,y=39
 	BonusType=BONUS_IVORY
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=90,y=40
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Delhi
 		CityPopulation=8
 		BuildingType=BUILDING_STABLE
@@ -35160,7 +35020,7 @@ BeginPlot
 		BuildingType=BUILDING_HINDU_TEMPLE
 		BuildingType=BUILDING_HINDU_MONASTERY
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=100, (Independent)
+		Player44Culture=100
 	EndCity
 EndPlot
 BeginPlot
@@ -35207,9 +35067,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=90,y=48
@@ -35478,31 +35338,30 @@ EndPlot
 BeginPlot
 	x=91,y=29
 	BonusType=BONUS_ALUMINUM
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Madurai
 		CityPopulation=2
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=10, (Independent)
+		Player44Culture=10
 	EndCity
 EndPlot
 BeginPlot
@@ -35536,30 +35395,29 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=91,y=34
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Golkonda
 		CityPopulation=2
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player45Culture=50, (Independent2)
+		Player45Culture=50
 	EndCity
 EndPlot
 BeginPlot
@@ -35632,10 +35490,10 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=91,y=45
-	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	ImprovementType=IMPROVEMENT_VILLAGE
 EndPlot
 BeginPlot
 	x=91,y=46
@@ -35648,9 +35506,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=91,y=48
@@ -35942,32 +35800,31 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=92,y=32
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Kanchipuram
 		CityPopulation=2
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=50, (Independent)
+		Player44Culture=50
 	EndCity
 EndPlot
 BeginPlot
@@ -36065,9 +35922,9 @@ BeginPlot
 	x=92,y=48
 	isNOfRiver
 	RiverWEDirection=1
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=92,y=49
@@ -36447,11 +36304,11 @@ BeginPlot
 	x=93,y=48
 	isNOfRiver
 	RiverWEDirection=1
-	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	RouteType=ROUTE_ROAD
+	ImprovementType=IMPROVEMENT_VILLAGE
 EndPlot
 BeginPlot
 	x=93,y=49
@@ -36784,20 +36641,19 @@ BeginPlot
 	x=94,y=40
 	isNOfRiver
 	RiverWEDirection=1
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
+		UnitType=UNIT_ARCHER, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Pataliputra
 		CityPopulation=8
 		BuildingType=BUILDING_STABLE
@@ -36817,7 +36673,7 @@ BeginPlot
 		HolyCityReligionType=RELIGION_HINDUISM
 		ReligionType=RELIGION_BUDDHISM
 		HolyCityReligionType=RELIGION_BUDDHISM
-		Player45Culture=50, (Independent2)
+		Player45Culture=50
 	EndCity
 EndPlot
 BeginPlot
@@ -36858,9 +36714,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=94,y=48
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=94,y=49
@@ -37157,32 +37013,31 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=95,y=37
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Kolkata
 		CityPopulation=2
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player45Culture=50, (Independent2)
+		Player45Culture=50
 	EndCity
 EndPlot
 BeginPlot
@@ -37245,27 +37100,26 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=95,y=47
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
-	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Dunhuang
 		CityPopulation=3
+		ReligionType=RELIGION_BUDDHISM
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
-		ReligionType=RELIGION_BUDDHISM
-		Player44Culture=20, (Independent)
+		Player44Culture=20
 	EndCity
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
+	EndUnit
 EndPlot
 BeginPlot
 	x=95,y=48
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=95,y=49
@@ -37626,17 +37480,17 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=96,y=47
-	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
+	ImprovementType=IMPROVEMENT_VILLAGE
 	PlotType=2
 EndPlot
 BeginPlot
 	x=96,y=48
 	BonusType=BONUS_COTTON
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=96,y=49
@@ -37992,9 +37846,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=97,y=47
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=97,y=48
@@ -38299,21 +38153,21 @@ BeginPlot
 	x=98,y=36
 	RiverNSDirection=2
 	isWOfRiver
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent)
+		UnitType=UNIT_ARCHER, UnitOwner=44
 	EndUnit
 	BeginCity
-		CityOwner=44, (Independent)
+		CityOwner=44
 		CityName=Pagan
 		CityPopulation=4
 		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_SHWEDAGON_PAYA
 		ReligionType=RELIGION_BUDDHISM
-		Player44Culture=10, (Independent)
+		Player44Culture=10
 	EndCity
+
 EndPlot
 BeginPlot
 	x=98,y=37
@@ -38393,9 +38247,9 @@ EndPlot
 BeginPlot
 	x=98,y=47
 	BonusType=BONUS_OIL
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=98,y=48
@@ -38739,19 +38593,9 @@ BeginPlot
 	x=99,y=41
 	RiverNSDirection=2
 	isWOfRiver
-(	RouteType=ROUTE_ROAD)
+	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-(	BeginUnit)
-(		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent))
-(	EndUnit)
-(	BeginCity)
-(		CityOwner=44, (Independent))
-(		CityName=Chengdu)
-(		CityPopulation=2)
-(		BuildingType=BUILDING_GRANARY)
-(		ReligionType=RELIGION_CONFUCIANISM)
-(	EndCity)
 EndPlot
 BeginPlot
 	x=99,y=42
@@ -38763,8 +38607,8 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	BonusType=BONUS_PIG
-	ImprovementType=IMPROVEMENT_PASTURE
 	TerrainType=TERRAIN_GRASS
+	ImprovementType=IMPROVEMENT_PASTURE
 	PlotType=1
 EndPlot
 BeginPlot
@@ -38783,9 +38627,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=99,y=47
@@ -39173,57 +39017,23 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=100,y=44
-	RouteType=ROUTE_ROAD
+	FeatureType=FEATURE_FOREST, FeatureVariety=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-(	BeginUnit)
-(		UnitType=UNIT_HORSE_ARCHER, UnitOwner=1, (China))
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_CHINESE_CHOKONU, UnitOwner=1, (China))
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_CHINESE_CHOKONU, UnitOwner=1, (China))
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_SWORDSMAN, UnitOwner=1, (China))
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_SWORDSMAN, UnitOwner=1, (China))
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_SPEARMAN, UnitOwner=1, (China))
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_ARCHER, UnitOwner=1, (China))
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_WORKER, UnitOwner=1, (China))
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_WORKER, UnitOwner=1, (China))
-(	EndUnit)
 	BeginCity
-		CityOwner=45, (China)
-		CityName=Chang'an, (Xi'an)
-		CityPopulation=1, (4)
-(		BuildingType=BUILDING_PALACE)
-(		BuildingType=BUILDING_BARRACKS)
-(		BuildingType=BUILDING_FORGE)
-(		BuildingType=BUILDING_CHINESE_TAIXUE)
-(		BuildingType=BUILDING_CONFUCIAN_TEMPLE)
-(		ReligionType=RELIGION_CONFUCIANISM)
-(		ReligionType=RELIGION_TAOISM)
-		Player45Culture=3000, (100)
+		CityOwner=45
+		CityName=Chang'an
+		CityPopulation=1
+		Player45Culture=3000
 	EndCity
 EndPlot
 BeginPlot
 	x=100,y=45
 	BonusType=BONUS_IRON
 	ImprovementType=IMPROVEMENT_MINE
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=100,y=46
@@ -39601,15 +39411,15 @@ BeginPlot
 	x=101,y=43
 	BonusType=BONUS_COAL
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=101,y=44
 	BonusType=BONUS_WHEAT
-	ImprovementType=IMPROVEMENT_FARM
 	TerrainType=TERRAIN_GRASS
+	ImprovementType=IMPROVEMENT_FARM
 	PlotType=2
 EndPlot
 BeginPlot
@@ -39983,7 +39793,7 @@ BeginPlot
 	x=102,y=41
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
-	BeginCity, (Removed after game start)
+	BeginCity
 		CityOwner=45
 		CityName=Guiyang
 		CityPopulation=1
@@ -40011,9 +39821,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=102,y=44
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
+	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=102,y=45
@@ -40032,31 +39842,32 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=102,y=47
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=45, (China)
+		UnitType=UNIT_SPEARMAN, UnitOwner=45
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=45, (China)
+		UnitType=UNIT_SPEARMAN, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (China)
+		CityOwner=45
 		CityName=Beijing
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_CHINESE_TAIXUE
+		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_MARKET
-		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		BuildingType=BUILDING_TAOIST_TEMPLE
+		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_GREAT_WALL
 		ReligionType=RELIGION_BUDDHISM
-		ReligionType=RELIGION_CONFUCIANISM
 		ReligionType=RELIGION_TAOISM
-		Player45Culture=100, (20)
+		ReligionType=RELIGION_CONFUCIANISM
+		HolyCityReligionType=RELIGION_TAOISM
+		HolyCityReligionType=RELIGION_CONFUCIANISM
+		Player45Culture=100
 	EndCity
 EndPlot
 BeginPlot
@@ -40425,26 +40236,27 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=103,y=44
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45, (China)
+		UnitType=UNIT_ARCHER, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (China)
+		CityOwner=45
 		CityName=Kaifeng
 		CityPopulation=2
-		BuildingType=BUILDING_GRANARY
-		BuildingType=BUILDING_CHINESE_TAIXUE
+		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_MARKET
-		BuildingType=BUILDING_BUDDHIST_TEMPLE
+		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		BuildingType=BUILDING_TAOIST_TEMPLE
+		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		ReligionType=RELIGION_BUDDHISM
-		ReligionType=RELIGION_CONFUCIANISM
 		ReligionType=RELIGION_TAOISM
-		Player45Culture=100, (20)
+		ReligionType=RELIGION_CONFUCIANISM
+		HolyCityReligionType=RELIGION_TAOISM
+		HolyCityReligionType=RELIGION_CONFUCIANISM
+		Player45Culture=100
 	EndCity
 EndPlot
 BeginPlot
@@ -41192,23 +41004,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=105,y=39
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=45, (Independent2)
+		UnitType=UNIT_SPEARMAN, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Guangzhou
 		CityPopulation=3
-		BuildingType=BUILDING_GRANARY
-		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_MARKET
+		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_SMOKEHOUSE
 		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		ReligionType=RELIGION_BUDDHISM
-		Player45Culture=100, (0)
+		Player45Culture=100
 	EndCity
 EndPlot
 BeginPlot
@@ -41239,19 +41050,18 @@ BeginPlot
 	x=105,y=43
 	isNOfRiver
 	RiverWEDirection=1
-	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45, (China)
+		UnitType=UNIT_ARCHER, UnitOwner=45
 	EndUnit
 	BeginCity
-		CityOwner=45, (China)
+		CityOwner=45
 		CityName=Nanjing
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_CHINESE_TAIXUE
+		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		BuildingType=BUILDING_CONFUCIAN_MONASTERY
@@ -41260,10 +41070,10 @@ BeginPlot
 		BuildingType=BUILDING_TAOIST_MONASTERY
 		BuildingType=BUILDING_TAOIST_SHRINE
 		ReligionType=RELIGION_CONFUCIANISM
-		HolyCityReligionType=RELIGION_CONFUCIANISM
 		ReligionType=RELIGION_TAOISM
+		HolyCityReligionType=RELIGION_CONFUCIANISM
 		HolyCityReligionType=RELIGION_TAOISM
-		Player45Culture=100, (20)
+		Player45Culture=100
 	EndCity
 EndPlot
 BeginPlot
@@ -41295,27 +41105,8 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=105,y=49
-(	RouteType=ROUTE_ROAD)
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-(	BeginUnit)
-(		UnitType=UNIT_ARCHER, UnitOwner=49, (Barbarian))
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_WARRIOR, UnitOwner=49, (Barbarian))
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_WARRIOR, UnitOwner=49, (Barbarian))
-(	EndUnit)
-(	BeginCity)
-(		CityOwner=49, (Barbarian))
-(		CityName=Simiyan hoton)
-(		CityPopulation=2)
-(		BuildingType=BUILDING_WALLS)
-(		BuildingType=BUILDING_GRANARY)
-(		BuildingType=BUILDING_CONFUCIAN_TEMPLE)
-(		ReligionType=RELIGION_CONFUCIANISM)
-(	EndCity)
 EndPlot
 BeginPlot
 	x=105,y=50
@@ -41664,12 +41455,12 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=106,y=43
-	RiverNSDirection=0
+	BonusType=BONUS_RICE
+	ImprovementType=IMPROVEMENT_FARM
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
-	BonusType=BONUS_RICE
-	ImprovementType=IMPROVEMENT_FARM
+	RiverNSDirection=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 EndPlot
@@ -42031,11 +41822,11 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=107,y=42
-	RouteType=ROUTE_ROAD
+	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginCity
-		CityOwner=45, (Independent2)
+		CityOwner=45
 		CityName=Hangzhou
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -42044,7 +41835,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		ReligionType=RELIGION_BUDDHISM
 		ReligionType=RELIGION_CONFUCIANISM
-		Player45Culture=100, (0)
+		Player45Culture=100
 	EndCity
 EndPlot
 BeginPlot
@@ -42836,42 +42627,6 @@ BeginPlot
 	x=109,y=46
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-(	BeginUnit)
-(		UnitType=UNIT_HEAVY_SWORDSMAN, UnitOwner=12, (Korea)) (AI only)
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_HEAVY_SWORDSMAN, UnitOwner=12, (Korea)) (AI only)
-(	EndUnit)
-	BeginUnit
-		UnitType=UNIT_HORSE_ARCHER, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_AXEMAN, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_AXEMAN, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_AXEMAN, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_CONFUCIAN_MISSIONARY, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BUDDHIST_MISSIONARY, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SETTLER, UnitOwner=12, (Korea)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SETTLER, UnitOwner=12, (Korea)
-	EndUnit
 EndPlot
 BeginPlot
 	x=109,y=47
@@ -43983,12 +43738,6 @@ BeginPlot
 	BonusType=BONUS_FISH
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	BeginUnit
-		UnitType=UNIT_WORK_BOAT, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_WORK_BOAT, UnitOwner=15, (Japan)
-	EndUnit
 EndPlot
 BeginPlot
 	x=112,y=47
@@ -44351,51 +44100,6 @@ BeginPlot
 	x=113,y=45
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-(	BeginUnit)
-(		UnitType=UNIT_JAPANESE_SAMURAI, UnitOwner=15, (Japan)) (AI only)
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_JAPANESE_SAMURAI, UnitOwner=15, (Japan)) (AI only)
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_JAPANESE_SAMURAI, UnitOwner=15, (Japan)) (AI only)
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_CROSSBOWMAN, UnitOwner=15, (Japan)) (AI only)
-(	EndUnit)
-(	BeginUnit)
-(		UnitType=UNIT_CROSSBOWMAN, UnitOwner=15, (Japan)) (AI only)
-(	EndUnit)
-	BeginUnit
-		UnitType=UNIT_SWORDSMAN, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SWORDSMAN, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BUDDHIST_MISSIONARY, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BUDDHIST_MISSIONARY, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_BUDDHIST_MISSIONARY, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SETTLER, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SETTLER, UnitOwner=15, (Japan)
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_SETTLER, UnitOwner=15, (Japan)
-	EndUnit
 EndPlot
 BeginPlot
 	x=113,y=46

--- a/PrivateMaps/RFC 600 AD.CivBeyondSwordWBSave
+++ b/PrivateMaps/RFC 600 AD.CivBeyondSwordWBSave
@@ -7206,7 +7206,7 @@ EndPlot
 BeginPlot
 	x=17,y=65
 	TerrainType=TERRAIN_SNOW
-	PlotType=3
+	PlotType=2
 EndPlot
 BeginPlot
 	x=17,y=66
@@ -8892,18 +8892,18 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=22,y=35
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MAYAN_HOLKAN, UnitOwner=46
+		UnitType=UNIT_MAYAN_HOLKAN, UnitOwner=46, (Native)
 	EndUnit
 	BeginCity
-		CityOwner=46
+		CityOwner=46, (Native)
 		CityName=Yax Mutal
 		CityPopulation=2
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_MAYAN_BALL_COURT
-		Player46Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -9298,21 +9298,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=23,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_MAYAN_HOLKAN, UnitOwner=46
+		UnitType=UNIT_MAYAN_HOLKAN, UnitOwner=46, (Native)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_WORKER, UnitOwner=46
+		UnitType=UNIT_WORKER, UnitOwner=46, (Native)
 	EndUnit
 	BeginCity
-		CityOwner=46
+		CityOwner=46, (Native)
 		CityName=Chich'en Itz&#225;
 		CityPopulation=2
 		BuildingType=BUILDING_MAYAN_BALL_COURT
 		BuildingType=BUILDING_TEMPLE_OF_KUKULKAN
-		Player46Culture=10
+		Player46Culture=10, (Native)
 	EndCity
 EndPlot
 BeginPlot
@@ -19604,19 +19605,19 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=51,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Marrakus
 		CityPopulation=2
-		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		Player44Culture=1
+		BuildingType=BUILDING_HARBOR
 	EndCity
 EndPlot
 BeginPlot
@@ -20047,9 +20048,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=52,y=47
@@ -20428,26 +20429,26 @@ EndPlot
 BeginPlot
 	x=53,y=47
 	BonusType=BONUS_WINE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=53,y=48
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Burdigala
 		CityPopulation=3
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
 		ReligionType=RELIGION_CATHOLICISM
-		Player44Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -20788,17 +20789,17 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=54,y=42
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=54,y=43
 	BonusType=BONUS_SILVER
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=54,y=44
@@ -20826,9 +20827,9 @@ BeginPlot
 	RiverNSDirection=0
 	isWOfRiver
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=54,y=48
@@ -21181,28 +21182,27 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=55,y=44
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=45
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Barcelona
 		CityPopulation=2
-		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_HARBOR
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
-		Player45Culture=1
 	EndCity
 EndPlot
 BeginPlot
 	x=55,y=45
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=55,y=46
@@ -21212,9 +21212,9 @@ EndPlot
 BeginPlot
 	x=55,y=47
 	BonusType=BONUS_WHEAT
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=55,y=48
@@ -21572,22 +21572,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=56,y=46
-	isWOfRiver
 	RiverNSDirection=2
+	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Massilia
 		CityPopulation=3
-		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_HARBOR
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
-		Player44Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -21596,25 +21596,25 @@ BeginPlot
 	isWOfRiver
 	BonusType=BONUS_ALUMINUM
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=56,y=48
 	RiverNSDirection=2
 	isWOfRiver
 	BonusType=BONUS_WINE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=56,y=49
 	BonusType=BONUS_PIG
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=56,y=50
@@ -21918,9 +21918,9 @@ BeginPlot
 	RiverWEDirection=1
 	isWOfRiver
 	BonusType=BONUS_SHEEP
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=57,y=40
@@ -21955,9 +21955,9 @@ EndPlot
 BeginPlot
 	x=57,y=46
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=57,y=47
@@ -22271,22 +22271,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=58,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=58,y=38
 	BonusType=BONUS_STONE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=58,y=39
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=58,y=40
@@ -22322,9 +22322,9 @@ EndPlot
 BeginPlot
 	x=58,y=46
 	BonusType=BONUS_STONE
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=58,y=47
@@ -22644,9 +22644,9 @@ EndPlot
 BeginPlot
 	x=59,y=37
 	BonusType=BONUS_WHEAT
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=59,y=38
@@ -22695,9 +22695,9 @@ EndPlot
 BeginPlot
 	x=59,y=46
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=59,y=47
@@ -23027,19 +23027,20 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=60,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_SPEARMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Tripolis
 		CityPopulation=2
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -23077,61 +23078,62 @@ BeginPlot
 	x=60,y=44
 	RiverNSDirection=2
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=45
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=45
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
+		UnitType=UNIT_PIKEMAN, UnitOwner=45, (Independent2)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
+		UnitType=UNIT_PIKEMAN, UnitOwner=45, (Independent2)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CATHOLIC_MISSIONARY, UnitOwner=45
+		UnitType=UNIT_CATHOLIC_MISSIONARY, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_WORKER, UnitOwner=45
+		UnitType=UNIT_WORKER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Roma
 		CityPopulation=4
-		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_ROMAN_FORUM
-		BuildingType=BUILDING_COLOSSEUM
 		BuildingType=BUILDING_CATHOLIC_TEMPLE
 		BuildingType=BUILDING_CATHOLIC_MONASTERY
 		BuildingType=BUILDING_CATHOLIC_SHRINE
+		BuildingType=BUILDING_COLOSSEUM
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_CATHOLICISM
 		HolyCityReligionType=RELIGION_CATHOLICISM
-		Player45Culture=100
+		Player45Culture=100, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
 	x=60,y=45
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=60,y=46
@@ -23145,9 +23147,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	BonusType=BONUS_WHEAT
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=60,y=48
@@ -23206,6 +23208,12 @@ BeginPlot
 	x=60,y=56
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+(	BeginUnit)
+(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)) (AI only)
+(	EndUnit)
 EndPlot
 BeginPlot
 	x=60,y=57
@@ -23216,11 +23224,66 @@ BeginPlot
 	x=60,y=58
 	TerrainType=TERRAIN_COAST
 	PlotType=3
+	BeginUnit
+		UnitType=UNIT_GALLEY, UnitOwner=16, (Vikings)
+		UnitAIType=UNITAI_SETTLER_SEA
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEY, UnitOwner=16, (Vikings)
+		UnitAIType=UNITAI_EXPLORE_SEA
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEY, UnitOwner=16, (Vikings)
+		UnitAIType=UNITAI_EXPLORE_SEA
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_WORK_BOAT, UnitOwner=16, (Vikings)
+	EndUnit
+(	BeginUnit)
+(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (Human only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)) (Human only)
+(	EndUnit)
 EndPlot
 BeginPlot
 	x=60,y=59
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+(	BeginUnit)
+(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (Human only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (Human only)
+(	EndUnit)
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SWORDSMAN, UnitOwner=16, (Vikings)
+		UnitAIType=UNITAI_ATTACK_CITY
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SWORDSMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_AXEMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_AXEMAN, UnitOwner=16, (Vikings)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SCOUT, UnitOwner=16, (Vikings)
+	EndUnit
+(	BeginUnit)
+(		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)) (Human only)
+(	EndUnit)
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)
+	EndUnit
 EndPlot
 BeginPlot
 	x=60,y=60
@@ -23467,9 +23530,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=61,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=61,y=38
@@ -23499,9 +23562,9 @@ EndPlot
 BeginPlot
 	x=61,y=43
 	BonusType=BONUS_PIG
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=61,y=44
@@ -23524,43 +23587,42 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=61,y=47
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_PIKEMAN, UnitOwner=44
+		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44, (Independent)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_CROSSBOWMAN, UnitOwner=44
+		UnitType=UNIT_PIKEMAN, UnitOwner=44, (Independent)
 		Level=3, Experience=5
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Venetia
 		CityPopulation=2
-		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_STABLE
+		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_FORGE
 		BuildingType=BUILDING_MARKET
 		ReligionType=RELIGION_CATHOLICISM
-		Player44Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -23883,9 +23945,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=62,y=36
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=62,y=37
@@ -23916,20 +23978,19 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=62,y=42
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
-		CityName=Napoli
+		CityOwner=14, (Byzantium)
+		CityName=Neapolis
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
 		ReligionType=RELIGION_CATHOLICISM
-		Player44Culture=10
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -23968,19 +24029,19 @@ BeginPlot
 	x=62,y=49
 	RiverNSDirection=2
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
 		PromotionType=PROMOTION_CITY_GARRISON1
 		PromotionType=PROMOTION_CITY_GARRISON2
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Vindobona
 		CityPopulation=1
 		BuildingType=BUILDING_GRANARY
-		Player45Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -24294,9 +24355,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=63,y=36
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=63,y=37
@@ -24326,9 +24387,9 @@ EndPlot
 BeginPlot
 	x=63,y=42
 	BonusType=BONUS_SHEEP
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=63,y=43
@@ -24432,6 +24493,12 @@ BeginPlot
 	RiverWEDirection=1
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+(	BeginUnit)
+(		UnitType=UNIT_LONGBOWMAN, UnitOwner=16, (Vikings)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_SETTLER, UnitOwner=16, (Vikings)) (AI only)
+(	EndUnit)
 EndPlot
 BeginPlot
 	x=63,y=60
@@ -24688,16 +24755,17 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=64,y=36
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=44
+		UnitType=UNIT_SPEARMAN, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Hesperides
 		CityPopulation=2
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -25106,9 +25174,9 @@ EndPlot
 BeginPlot
 	x=65,y=37
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=65,y=38
@@ -25138,9 +25206,9 @@ EndPlot
 BeginPlot
 	x=65,y=43
 	FeatureType=FEATURE_FOREST, FeatureVariety=1
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=65,y=44
@@ -25150,19 +25218,19 @@ EndPlot
 BeginPlot
 	x=65,y=45
 	BonusType=BONUS_ALUMINUM
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
-		CityName=Belgrad
+		CityOwner=14, (Byzantium)
+		CityName=Singidunon
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
 		ReligionType=RELIGION_ORTHODOXY
-		Player44Culture=10
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -25528,9 +25596,9 @@ BeginPlot
 	x=66,y=37
 	BonusType=BONUS_DYE
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=66,y=38
@@ -25558,10 +25626,10 @@ EndPlot
 BeginPlot
 	x=66,y=42
 	BonusType=BONUS_IRON
-	TerrainType=TERRAIN_PLAINS
-	PlotType=1
 	ImprovementType=IMPROVEMENT_MINE
 	RouteType=ROUTE_ROMAN_ROAD
+	TerrainType=TERRAIN_PLAINS
+	PlotType=1
 EndPlot
 BeginPlot
 	x=66,y=43
@@ -25572,9 +25640,9 @@ BeginPlot
 	x=66,y=44
 	BonusType=BONUS_SHEEP
 	ImprovementType=IMPROVEMENT_PASTURE
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=66,y=45
@@ -25938,14 +26006,15 @@ BeginPlot
 	x=67,y=36
 	RiverNSDirection=0
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=44
+		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
-		CityName=Alexandria
+		CityOwner=14, (Byzantium)
+		CityName=Alexandreia
 		CityPopulation=3
 		BuildingType=BUILDING_LIBRARY
 		BuildingType=BUILDING_GREAT_LIGHTHOUSE
@@ -25953,7 +26022,7 @@ BeginPlot
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_CATHOLICISM
-		Player44Culture=10
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -25979,30 +26048,30 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=67,y=41
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_WORKER, UnitOwner=44
+		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=44
+		UnitType=UNIT_WORKER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
-		CityName=Athenae
+		CityOwner=14, (Byzantium)
+		CityName=Athinai
 		CityPopulation=3
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_PAGAN_TEMPLE
 		BuildingType=BUILDING_LIBRARY
-		BuildingType=BUILDING_THEATRE
-		BuildingType=BUILDING_GREEK_ODEON
+		BuildingType=BUILDING_BYZANTINE_HIPPODROME
+		BuildingType=BUILDING_PARTHENON
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
-		BuildingType=BUILDING_PARTHENON
-		Player44Culture=50
+		Player14Culture=50, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -26019,9 +26088,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=67,y=44
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=67,y=45
@@ -26389,9 +26458,9 @@ BeginPlot
 	RiverWEDirection=0
 	isWOfRiver
 	BonusType=BONUS_WHEAT
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=68,y=37
@@ -26437,11 +26506,72 @@ BeginPlot
 	BonusType=BONUS_FISH
 	TerrainType=TERRAIN_COAST
 	PlotType=3
+	BeginUnit
+		UnitType=UNIT_TRIREME, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_TRIREME, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEY, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_GALLEY, UnitOwner=14, (Byzantium)
+	EndUnit
 EndPlot
 BeginPlot
 	x=68,y=45
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_BYZANTINE_CATAPHRACT, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_WORKER, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_WORKER, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_WORKER, UnitOwner=14, (Byzantium)
+	EndUnit
+	BeginCity
+		CityOwner=14, (Byzantium)
+		CityName=Konstantinoupolis
+		CityPopulation=4
+		BuildingType=BUILDING_PALACE
+		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_CASTLE
+		BuildingType=BUILDING_BARRACKS
+		BuildingType=BUILDING_STABLE
+		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_LIBRARY
+		BuildingType=BUILDING_BYZANTINE_HIPPODROME
+		BuildingType=BUILDING_MARKET
+		BuildingType=BUILDING_ORTHODOX_TEMPLE
+		BuildingType=BUILDING_THEODOSIAN_WALLS
+		BuildingType=BUILDING_HAGIA_SOPHIA
+		ReligionType=RELIGION_JUDAISM
+		ReligionType=RELIGION_ORTHODOXY
+		ReligionType=RELIGION_CATHOLICISM
+		Player14Culture=250, (Byzantium)
+	EndCity
 EndPlot
 BeginPlot
 	x=68,y=46
@@ -26768,31 +26898,32 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=69,y=34
-	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	BonusType=BONUS_MARBLE
+	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 EndPlot
 BeginPlot
 	x=69,y=35
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
+	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_SPEARMAN, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=14, (Byzantium)
 		CityName=Memphis
 		CityPopulation=2
 		BuildingType=BUILDING_PYRAMIDS
 		ReligionType=RELIGION_JUDAISM
 		ReligionType=RELIGION_ORTHODOXY
-		Player44Culture=10
+		Player14Culture=10, (Byzantium)
 	EndCity
-	PlotType=2
 EndPlot
 BeginPlot
 	x=69,y=36
@@ -26800,9 +26931,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=69,y=37
@@ -26844,10 +26975,10 @@ EndPlot
 BeginPlot
 	x=69,y=44
 	BonusType=BONUS_SHEEP
-	TerrainType=TERRAIN_PLAINS
-	PlotType=2
 	ImprovementType=IMPROVEMENT_PASTURE
 	RouteType=ROUTE_ROMAN_ROAD
+	TerrainType=TERRAIN_PLAINS
+	PlotType=2
 EndPlot
 BeginPlot
 	x=69,y=45
@@ -26857,9 +26988,9 @@ EndPlot
 BeginPlot
 	x=69,y=46
 	BonusType=BONUS_CLAM
+	ImprovementType=IMPROVEMENT_FISHING_BOATS
 	TerrainType=TERRAIN_COAST
 	PlotType=3
-	ImprovementType=IMPROVEMENT_FISHING_BOATS
 EndPlot
 BeginPlot
 	x=69,y=47
@@ -27154,7 +27285,6 @@ BeginPlot
 	x=70,y=31
 	BonusType=BONUS_GOLD
 	TerrainType=TERRAIN_DESERT
-	BonusType=BONUS_GOLD
 	PlotType=2
 EndPlot
 BeginPlot
@@ -27171,10 +27301,10 @@ EndPlot
 BeginPlot
 	x=70,y=34
 	BonusType=BONUS_HORSE
-	TerrainType=TERRAIN_DESERT
-	PlotType=2
 	ImprovementType=IMPROVEMENT_PASTURE
 	RouteType=ROUTE_ROAD
+	TerrainType=TERRAIN_DESERT
+	PlotType=2
 EndPlot
 BeginPlot
 	x=70,y=35
@@ -27185,9 +27315,9 @@ EndPlot
 BeginPlot
 	x=70,y=36
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=70,y=37
@@ -27230,9 +27360,9 @@ BeginPlot
 	x=70,y=44
 	BonusType=BONUS_COAL
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROMAN_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROMAN_ROAD
 EndPlot
 BeginPlot
 	x=70,y=45
@@ -27564,9 +27694,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=71,y=36
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=71,y=37
@@ -27603,12 +27733,12 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=71,y=43
-	isWOfRiver
 	RiverNSDirection=0
-	TerrainType=TERRAIN_PLAINS
+	isWOfRiver
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
-	PlotType=1
 	RouteType=ROUTE_ROMAN_ROAD
+	TerrainType=TERRAIN_PLAINS
+	PlotType=1
 EndPlot
 BeginPlot
 	x=71,y=44
@@ -27911,21 +28041,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=72,y=29
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=45
+		UnitType=UNIT_SPEARMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Aksum
 		CityPopulation=2
 		BuildingType=BUILDING_ETHIOPIAN_STELE
 		ReligionType=RELIGION_ORTHODOXY
-		Player45Culture=50
+		Player45Culture=50, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
@@ -27966,9 +28097,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=72,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=72,y=38
@@ -28000,19 +28131,19 @@ BeginPlot
 	x=72,y=43
 	isNOfRiver
 	RiverWEDirection=3
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
-		CityName=Iconium
+		CityOwner=14, (Byzantium)
+		CityName=Ikonion
 		CityPopulation=2
 		BuildingType=BUILDING_MARKET
 		ReligionType=RELIGION_ORTHODOXY
-		Player44Culture=10
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -28366,40 +28497,41 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=73,y=38
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=14, (Byzantium)
 		CityName=Hierousalem
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
-		BuildingType=BUILDING_ORTHODOX_SHRINE
 		BuildingType=BUILDING_JEWISH_TEMPLE
 		BuildingType=BUILDING_JEWISH_SHRINE
+		BuildingType=BUILDING_ORTHODOX_SHRINE
 		ReligionType=RELIGION_JUDAISM
-		ReligionType=RELIGION_ORTHODOXY
-		ReligionType=RELIGION_CATHOLICISM
-		HolyCityReligionType=RELIGION_ORTHODOXY
 		HolyCityReligionType=RELIGION_JUDAISM
-		Player44Culture=10
+		ReligionType=RELIGION_ORTHODOXY
+		HolyCityReligionType=RELIGION_ORTHODOXY
+		ReligionType=RELIGION_CATHOLICISM
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
 	x=73,y=39
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=73,y=40
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=73,y=41
@@ -28410,16 +28542,16 @@ EndPlot
 BeginPlot
 	x=73,y=42
 	BonusType=BONUS_WINE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=73,y=43
 	BonusType=BONUS_WHEAT
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=73,y=44
@@ -28784,21 +28916,22 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=74,y=40
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=14, (Byzantium)
 		CityName=Damaskos
 		CityPopulation=3
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
-		BuildingType=BUILDING_WALLS
-		ReligionType=RELIGION_ORTHODOXY
 		ReligionType=RELIGION_JUDAISM
-		Player44Culture=10
+		ReligionType=RELIGION_ORTHODOXY
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -28807,9 +28940,9 @@ BeginPlot
 	isWOfRiver
 	BonusType=BONUS_WHEAT
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=74,y=42
@@ -28830,10 +28963,10 @@ EndPlot
 BeginPlot
 	x=74,y=44
 	BonusType=BONUS_HORSE
-	TerrainType=TERRAIN_PLAINS
-	PlotType=1
 	ImprovementType=IMPROVEMENT_PASTURE
 	RouteType=ROUTE_ROAD
+	TerrainType=TERRAIN_PLAINS
+	PlotType=1
 EndPlot
 BeginPlot
 	x=74,y=45

--- a/PrivateMaps/RFC 600 AD.CivBeyondSwordWBSave
+++ b/PrivateMaps/RFC 600 AD.CivBeyondSwordWBSave
@@ -29329,9 +29329,9 @@ BeginPlot
 	x=75,y=42
 	BonusType=BONUS_SHEEP
 	ImprovementType=IMPROVEMENT_PASTURE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=75,y=43
@@ -29340,20 +29340,21 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=75,y=44
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=14, (Byzantium)
 	EndUnit
 	BeginCity
-		CityOwner=44
-		CityName=Trapezus
+		CityOwner=14, (Byzantium)
+		CityName=Trapezounta
 		CityPopulation=3
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_HARBOR
 		ReligionType=RELIGION_ORTHODOXY
-		Player44Culture=10
+		Player14Culture=10, (Byzantium)
 	EndCity
 EndPlot
 BeginPlot
@@ -29648,18 +29649,17 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=76,y=30
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Sana'a
 		CityPopulation=1
 		BuildingType=BUILDING_GRANARY
-		Player45Culture=1
 	EndCity
 EndPlot
 BeginPlot
@@ -29731,9 +29731,9 @@ BeginPlot
 	x=76,y=42
 	RiverNSDirection=2
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=76,y=43
@@ -30094,17 +30094,18 @@ BeginPlot
 	isWOfRiver
 	BonusType=BONUS_STONE
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Tisfun
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
-		Player45Culture=10
+		Player45Culture=10, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
@@ -30112,9 +30113,9 @@ BeginPlot
 	RiverNSDirection=2
 	isWOfRiver
 	BonusType=BONUS_OIL
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=77,y=42
@@ -30473,16 +30474,15 @@ BeginPlot
 	x=78,y=39
 	RiverNSDirection=2
 	isWOfRiver
-	RiverNSDirection=2
 	FeatureType=FEATURE_FLOOD_PLAINS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 EndPlot
 BeginPlot
 	x=78,y=40
-	BonusType=BONUS_SHEEP
 	isNOfRiver
 	RiverWEDirection=1
+	BonusType=BONUS_SHEEP
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 EndPlot
@@ -30494,9 +30494,9 @@ EndPlot
 BeginPlot
 	x=78,y=42
 	BonusType=BONUS_COPPER
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=78,y=43
@@ -30851,9 +30851,9 @@ EndPlot
 BeginPlot
 	x=79,y=41
 	BonusType=BONUS_WHEAT
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=79,y=42
@@ -31219,9 +31219,9 @@ EndPlot
 BeginPlot
 	x=80,y=42
 	BonusType=BONUS_OIL
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=80,y=43
@@ -31598,9 +31598,9 @@ EndPlot
 BeginPlot
 	x=81,y=42
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=81,y=43
@@ -31937,23 +31937,24 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=82,y=38
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Sirajis
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GROCER
-		BuildingType=BUILDING_ZOROASTRIAN_SHRINE
 		BuildingType=BUILDING_ZOROASTRIAN_TEMPLE
+		BuildingType=BUILDING_ZOROASTRIAN_SHRINE
 		ReligionType=RELIGION_ZOROASTRIANISM
 		HolyCityReligionType=RELIGION_ZOROASTRIANISM
-		Player45Culture=10
+		Player45Culture=10, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
@@ -31974,9 +31975,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=82,y=42
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=82,y=43
@@ -32339,31 +32340,31 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=83,y=43
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=83,y=44
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=83,y=45
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Merv
 		CityPopulation=2
 		BuildingType=BUILDING_STABLE
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=83,y=46
@@ -32714,28 +32715,29 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=84,y=41
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
+	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent)
 		CityName=Herat
 		CityPopulation=4
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GROCER
-		Player45Culture=10
+		Player45Culture=10, (Independent)
 	EndCity
-	PlotType=2
 EndPlot
 BeginPlot
 	x=84,y=42
 	BonusType=BONUS_SHEEP
 	ImprovementType=IMPROVEMENT_PASTURE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=84,y=43
@@ -32760,9 +32762,9 @@ BeginPlot
 	x=84,y=46
 	isNOfRiver
 	RiverWEDirection=3
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=84,y=47
@@ -33145,29 +33147,29 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=85,y=46
-	TerrainType=TERRAIN_PLAINS
 	BonusType=BONUS_SILK
+	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 EndPlot
 BeginPlot
 	x=85,y=47
 	RiverNSDirection=0
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Samarkand
 		CityPopulation=3
 		BuildingType=BUILDING_BARRACKS
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
-
 EndPlot
 BeginPlot
 	x=85,y=48
@@ -33545,9 +33547,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=86,y=48
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=86,y=49
@@ -33870,26 +33872,27 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=87,y=40
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
+	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Lavapuri
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		ReligionType=RELIGION_BUDDHISM
-		Player44Culture=50
+		Player44Culture=50, (Independent)
 	EndCity
-	PlotType=2
 EndPlot
 BeginPlot
 	x=87,y=41
@@ -33940,9 +33943,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=87,y=48
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=87,y=49
@@ -34236,28 +34239,29 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=88,y=34
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Mumbai
 		CityPopulation=3
 		BuildingType=BUILDING_STABLE
 		BuildingType=BUILDING_GRANARY
-		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_HARBOR
+		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=50
+		Player44Culture=50, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -34278,9 +34282,9 @@ EndPlot
 BeginPlot
 	x=88,y=37
 	BonusType=BONUS_HORSE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=88,y=38
@@ -34669,9 +34673,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=89,y=38
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=89,y=39
@@ -34722,24 +34726,24 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=45, (Independent2)
+	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Kashgar
 		CityPopulation=3
-		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
-		Player45Culture=40
+		Player45Culture=40, (Independent2)
 	EndCity
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=45
-	EndUnit
 EndPlot
 BeginPlot
 	x=89,y=47
@@ -35030,31 +35034,32 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=90,y=31
-	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
-	EndUnit
-	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
-	EndUnit
-	BeginCity
-		CityOwner=45
-		CityName=Vijayanagara
-		CityPopulation=2
-		BuildingType=BUILDING_GRANARY
-		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_WALLS
-		BuildingType=BUILDING_HINDU_TEMPLE
-		ReligionType=RELIGION_HINDUISM
-		Player45Culture=10
-	EndCity
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+	BeginUnit
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
+	EndUnit
+	BeginCity
+		CityOwner=45, (Independent2)
+		CityName=Vijayanagara
+		CityPopulation=2
+		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_SMOKEHOUSE
+		BuildingType=BUILDING_HINDU_TEMPLE
+		ReligionType=RELIGION_HINDUISM
+		Player45Culture=10, (Independent2)
+	EndCity
 EndPlot
 BeginPlot
 	x=90,y=32
@@ -35091,29 +35096,30 @@ BeginPlot
 	x=90,y=37
 	isNOfRiver
 	RiverWEDirection=3
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Bhopal
 		CityPopulation=2
-		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=50
+		Player44Culture=50, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -35125,22 +35131,23 @@ EndPlot
 BeginPlot
 	x=90,y=39
 	BonusType=BONUS_IVORY
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=90,y=40
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Delhi
 		CityPopulation=8
 		BuildingType=BUILDING_STABLE
@@ -35153,7 +35160,7 @@ BeginPlot
 		BuildingType=BUILDING_HINDU_TEMPLE
 		BuildingType=BUILDING_HINDU_MONASTERY
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=100
+		Player44Culture=100, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -35200,9 +35207,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=90,y=48
@@ -35471,30 +35478,31 @@ EndPlot
 BeginPlot
 	x=91,y=29
 	BonusType=BONUS_ALUMINUM
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Madurai
 		CityPopulation=2
-		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -35528,29 +35536,30 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=91,y=34
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Golkonda
 		CityPopulation=2
-		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_WALLS
+		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player45Culture=50
+		Player45Culture=50, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
@@ -35623,10 +35632,10 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=91,y=45
+	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	ImprovementType=IMPROVEMENT_VILLAGE
 EndPlot
 BeginPlot
 	x=91,y=46
@@ -35639,9 +35648,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=91,y=48
@@ -35933,31 +35942,32 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=92,y=32
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44, (Independent)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=44
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Kanchipuram
 		CityPopulation=2
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player44Culture=50
+		Player44Culture=50, (Independent)
 	EndCity
 EndPlot
 BeginPlot
@@ -36055,9 +36065,9 @@ BeginPlot
 	x=92,y=48
 	isNOfRiver
 	RiverWEDirection=1
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=92,y=49
@@ -36437,11 +36447,11 @@ BeginPlot
 	x=93,y=48
 	isNOfRiver
 	RiverWEDirection=1
+	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
-	ImprovementType=IMPROVEMENT_VILLAGE
 EndPlot
 BeginPlot
 	x=93,y=49
@@ -36774,19 +36784,20 @@ BeginPlot
 	x=94,y=40
 	isNOfRiver
 	RiverWEDirection=1
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Pataliputra
 		CityPopulation=8
 		BuildingType=BUILDING_STABLE
@@ -36806,7 +36817,7 @@ BeginPlot
 		HolyCityReligionType=RELIGION_HINDUISM
 		ReligionType=RELIGION_BUDDHISM
 		HolyCityReligionType=RELIGION_BUDDHISM
-		Player45Culture=50
+		Player45Culture=50, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
@@ -36847,9 +36858,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=94,y=48
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=94,y=49
@@ -37146,31 +37157,32 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=95,y=37
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
+		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_INDIAN_PATIYODHA, UnitOwner=45
+		UnitType=UNIT_INDIAN_PUNJABI_WORKER, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Kolkata
 		CityPopulation=2
+		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_WALLS
 		BuildingType=BUILDING_HARBOR
 		BuildingType=BUILDING_HINDU_TEMPLE
 		ReligionType=RELIGION_HINDUISM
-		Player45Culture=50
+		Player45Culture=50, (Independent2)
 	EndCity
 EndPlot
 BeginPlot
@@ -37233,26 +37245,27 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=95,y=47
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
+	BeginUnit
+		UnitType=UNIT_LONGBOWMAN, UnitOwner=44, (Independent)
+	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Dunhuang
 		CityPopulation=3
-		ReligionType=RELIGION_BUDDHISM
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_MARKET
-		Player44Culture=20
+		ReligionType=RELIGION_BUDDHISM
+		Player44Culture=20, (Independent)
 	EndCity
-	BeginUnit
-		UnitType=UNIT_LONGBOWMAN, UnitOwner=44
-	EndUnit
 EndPlot
 BeginPlot
 	x=95,y=48
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=95,y=49
@@ -37613,17 +37626,17 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=96,y=47
+	ImprovementType=IMPROVEMENT_VILLAGE
 	FeatureType=FEATURE_OASIS, FeatureVariety=0
 	TerrainType=TERRAIN_DESERT
-	ImprovementType=IMPROVEMENT_VILLAGE
 	PlotType=2
 EndPlot
 BeginPlot
 	x=96,y=48
 	BonusType=BONUS_COTTON
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=96,y=49
@@ -37979,9 +37992,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=97,y=47
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=97,y=48
@@ -38286,21 +38299,21 @@ BeginPlot
 	x=98,y=36
 	RiverNSDirection=2
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=44
+		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent)
 	EndUnit
 	BeginCity
-		CityOwner=44
+		CityOwner=44, (Independent)
 		CityName=Pagan
 		CityPopulation=4
 		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_SHWEDAGON_PAYA
 		ReligionType=RELIGION_BUDDHISM
-		Player44Culture=10
+		Player44Culture=10, (Independent)
 	EndCity
-
 EndPlot
 BeginPlot
 	x=98,y=37
@@ -38380,9 +38393,9 @@ EndPlot
 BeginPlot
 	x=98,y=47
 	BonusType=BONUS_OIL
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=98,y=48
@@ -38726,9 +38739,19 @@ BeginPlot
 	x=99,y=41
 	RiverNSDirection=2
 	isWOfRiver
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+(	RouteType=ROUTE_ROAD)
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+(	BeginUnit)
+(		UnitType=UNIT_ARCHER, UnitOwner=44, (Independent))
+(	EndUnit)
+(	BeginCity)
+(		CityOwner=44, (Independent))
+(		CityName=Chengdu)
+(		CityPopulation=2)
+(		BuildingType=BUILDING_GRANARY)
+(		ReligionType=RELIGION_CONFUCIANISM)
+(	EndCity)
 EndPlot
 BeginPlot
 	x=99,y=42
@@ -38740,8 +38763,8 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	BonusType=BONUS_PIG
-	TerrainType=TERRAIN_GRASS
 	ImprovementType=IMPROVEMENT_PASTURE
+	TerrainType=TERRAIN_GRASS
 	PlotType=1
 EndPlot
 BeginPlot
@@ -38760,9 +38783,9 @@ BeginPlot
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_DESERT
 	PlotType=2
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=99,y=47
@@ -39150,23 +39173,57 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=100,y=44
-	FeatureType=FEATURE_FOREST, FeatureVariety=1
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
+(	BeginUnit)
+(		UnitType=UNIT_HORSE_ARCHER, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_CHINESE_CHOKONU, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_CHINESE_CHOKONU, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_SWORDSMAN, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_SWORDSMAN, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_SPEARMAN, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_ARCHER, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_WORKER, UnitOwner=1, (China))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_WORKER, UnitOwner=1, (China))
+(	EndUnit)
 	BeginCity
-		CityOwner=45
-		CityName=Chang'an
-		CityPopulation=1
-		Player45Culture=3000
+		CityOwner=45, (China)
+		CityName=Chang'an, (Xi'an)
+		CityPopulation=1, (4)
+(		BuildingType=BUILDING_PALACE)
+(		BuildingType=BUILDING_BARRACKS)
+(		BuildingType=BUILDING_FORGE)
+(		BuildingType=BUILDING_CHINESE_TAIXUE)
+(		BuildingType=BUILDING_CONFUCIAN_TEMPLE)
+(		ReligionType=RELIGION_CONFUCIANISM)
+(		ReligionType=RELIGION_TAOISM)
+		Player45Culture=3000, (100)
 	EndCity
 EndPlot
 BeginPlot
 	x=100,y=45
 	BonusType=BONUS_IRON
 	ImprovementType=IMPROVEMENT_MINE
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=100,y=46
@@ -39544,15 +39601,15 @@ BeginPlot
 	x=101,y=43
 	BonusType=BONUS_COAL
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=101,y=44
 	BonusType=BONUS_WHEAT
-	TerrainType=TERRAIN_GRASS
 	ImprovementType=IMPROVEMENT_FARM
+	TerrainType=TERRAIN_GRASS
 	PlotType=2
 EndPlot
 BeginPlot
@@ -39926,7 +39983,7 @@ BeginPlot
 	x=102,y=41
 	FeatureType=FEATURE_FOREST, FeatureVariety=0
 	TerrainType=TERRAIN_GRASS
-	BeginCity
+	BeginCity, (Removed after game start)
 		CityOwner=45
 		CityName=Guiyang
 		CityPopulation=1
@@ -39954,9 +40011,9 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=102,y=44
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=1
-	RouteType=ROUTE_ROAD
 EndPlot
 BeginPlot
 	x=102,y=45
@@ -39975,32 +40032,31 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=102,y=47
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=45
+		UnitType=UNIT_SPEARMAN, UnitOwner=45, (China)
 	EndUnit
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=45
+		UnitType=UNIT_SPEARMAN, UnitOwner=45, (China)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (China)
 		CityName=Beijing
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_LIBRARY
+		BuildingType=BUILDING_CHINESE_TAIXUE
 		BuildingType=BUILDING_MARKET
+		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		BuildingType=BUILDING_TAOIST_TEMPLE
-		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_GREAT_WALL
 		ReligionType=RELIGION_BUDDHISM
-		ReligionType=RELIGION_TAOISM
 		ReligionType=RELIGION_CONFUCIANISM
-		HolyCityReligionType=RELIGION_TAOISM
-		HolyCityReligionType=RELIGION_CONFUCIANISM
-		Player45Culture=100
+		ReligionType=RELIGION_TAOISM
+		Player45Culture=100, (20)
 	EndCity
 EndPlot
 BeginPlot
@@ -40369,27 +40425,26 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=103,y=44
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_PLAINS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (China)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (China)
 		CityName=Kaifeng
 		CityPopulation=2
-		BuildingType=BUILDING_LIBRARY
-		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GRANARY
+		BuildingType=BUILDING_CHINESE_TAIXUE
+		BuildingType=BUILDING_MARKET
+		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		BuildingType=BUILDING_TAOIST_TEMPLE
-		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		ReligionType=RELIGION_BUDDHISM
-		ReligionType=RELIGION_TAOISM
 		ReligionType=RELIGION_CONFUCIANISM
-		HolyCityReligionType=RELIGION_TAOISM
-		HolyCityReligionType=RELIGION_CONFUCIANISM
-		Player45Culture=100
+		ReligionType=RELIGION_TAOISM
+		Player45Culture=100, (20)
 	EndCity
 EndPlot
 BeginPlot
@@ -41137,22 +41192,23 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=105,y=39
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_SPEARMAN, UnitOwner=45
+		UnitType=UNIT_SPEARMAN, UnitOwner=45, (Independent2)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Guangzhou
 		CityPopulation=3
-		BuildingType=BUILDING_LIBRARY
-		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
+		BuildingType=BUILDING_LIBRARY
+		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_BUDDHIST_TEMPLE
 		ReligionType=RELIGION_BUDDHISM
-		Player45Culture=100
+		Player45Culture=100, (0)
 	EndCity
 EndPlot
 BeginPlot
@@ -41183,18 +41239,19 @@ BeginPlot
 	x=105,y=43
 	isNOfRiver
 	RiverWEDirection=1
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 	BeginUnit
-		UnitType=UNIT_ARCHER, UnitOwner=45
+		UnitType=UNIT_ARCHER, UnitOwner=45, (China)
 	EndUnit
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (China)
 		CityName=Nanjing
 		CityPopulation=2
 		BuildingType=BUILDING_GRANARY
 		BuildingType=BUILDING_SMOKEHOUSE
-		BuildingType=BUILDING_LIBRARY
+		BuildingType=BUILDING_CHINESE_TAIXUE
 		BuildingType=BUILDING_MARKET
 		BuildingType=BUILDING_CONFUCIAN_TEMPLE
 		BuildingType=BUILDING_CONFUCIAN_MONASTERY
@@ -41203,10 +41260,10 @@ BeginPlot
 		BuildingType=BUILDING_TAOIST_MONASTERY
 		BuildingType=BUILDING_TAOIST_SHRINE
 		ReligionType=RELIGION_CONFUCIANISM
-		ReligionType=RELIGION_TAOISM
 		HolyCityReligionType=RELIGION_CONFUCIANISM
+		ReligionType=RELIGION_TAOISM
 		HolyCityReligionType=RELIGION_TAOISM
-		Player45Culture=100
+		Player45Culture=100, (20)
 	EndCity
 EndPlot
 BeginPlot
@@ -41238,8 +41295,27 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=105,y=49
+(	RouteType=ROUTE_ROAD)
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+(	BeginUnit)
+(		UnitType=UNIT_ARCHER, UnitOwner=49, (Barbarian))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_WARRIOR, UnitOwner=49, (Barbarian))
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_WARRIOR, UnitOwner=49, (Barbarian))
+(	EndUnit)
+(	BeginCity)
+(		CityOwner=49, (Barbarian))
+(		CityName=Simiyan hoton)
+(		CityPopulation=2)
+(		BuildingType=BUILDING_WALLS)
+(		BuildingType=BUILDING_GRANARY)
+(		BuildingType=BUILDING_CONFUCIAN_TEMPLE)
+(		ReligionType=RELIGION_CONFUCIANISM)
+(	EndCity)
 EndPlot
 BeginPlot
 	x=105,y=50
@@ -41588,12 +41664,12 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=106,y=43
-	BonusType=BONUS_RICE
-	ImprovementType=IMPROVEMENT_FARM
+	RiverNSDirection=0
 	isNOfRiver
 	RiverWEDirection=1
 	isWOfRiver
-	RiverNSDirection=0
+	BonusType=BONUS_RICE
+	ImprovementType=IMPROVEMENT_FARM
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
 EndPlot
@@ -41955,11 +42031,11 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=107,y=42
-	FeatureType=FEATURE_FOREST, FeatureVariety=0
+	RouteType=ROUTE_ROAD
 	TerrainType=TERRAIN_GRASS
 	PlotType=1
 	BeginCity
-		CityOwner=45
+		CityOwner=45, (Independent2)
 		CityName=Hangzhou
 		CityPopulation=3
 		BuildingType=BUILDING_GRANARY
@@ -41968,7 +42044,7 @@ BeginPlot
 		BuildingType=BUILDING_MARKET
 		ReligionType=RELIGION_BUDDHISM
 		ReligionType=RELIGION_CONFUCIANISM
-		Player45Culture=100
+		Player45Culture=100, (0)
 	EndCity
 EndPlot
 BeginPlot
@@ -42760,6 +42836,42 @@ BeginPlot
 	x=109,y=46
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+(	BeginUnit)
+(		UnitType=UNIT_HEAVY_SWORDSMAN, UnitOwner=12, (Korea)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_HEAVY_SWORDSMAN, UnitOwner=12, (Korea)) (AI only)
+(	EndUnit)
+	BeginUnit
+		UnitType=UNIT_HORSE_ARCHER, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_AXEMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_AXEMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_AXEMAN, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_CONFUCIAN_MISSIONARY, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BUDDHIST_MISSIONARY, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=12, (Korea)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=12, (Korea)
+	EndUnit
 EndPlot
 BeginPlot
 	x=109,y=47
@@ -43871,6 +43983,12 @@ BeginPlot
 	BonusType=BONUS_FISH
 	TerrainType=TERRAIN_COAST
 	PlotType=3
+	BeginUnit
+		UnitType=UNIT_WORK_BOAT, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_WORK_BOAT, UnitOwner=15, (Japan)
+	EndUnit
 EndPlot
 BeginPlot
 	x=112,y=47
@@ -44233,6 +44351,51 @@ BeginPlot
 	x=113,y=45
 	TerrainType=TERRAIN_GRASS
 	PlotType=2
+(	BeginUnit)
+(		UnitType=UNIT_JAPANESE_SAMURAI, UnitOwner=15, (Japan)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_JAPANESE_SAMURAI, UnitOwner=15, (Japan)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_JAPANESE_SAMURAI, UnitOwner=15, (Japan)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_CROSSBOWMAN, UnitOwner=15, (Japan)) (AI only)
+(	EndUnit)
+(	BeginUnit)
+(		UnitType=UNIT_CROSSBOWMAN, UnitOwner=15, (Japan)) (AI only)
+(	EndUnit)
+	BeginUnit
+		UnitType=UNIT_SWORDSMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SWORDSMAN, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_ARCHER, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BUDDHIST_MISSIONARY, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BUDDHIST_MISSIONARY, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_BUDDHIST_MISSIONARY, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=15, (Japan)
+	EndUnit
+	BeginUnit
+		UnitType=UNIT_SETTLER, UnitOwner=15, (Japan)
+	EndUnit
 EndPlot
 BeginPlot
 	x=113,y=46


### PR DESCRIPTION
I moved gold, starting units, 1700 added culture, great specialists, diplomacy bonuses and the 600 AD byzantine flip from python to the scenario file.

The 600 AD scenario was too big to display by itself in a seperate pull request and I assume that the 1700 AD scenario is the same. I can provide the files on CFC if you want.

The reason why I didn't do this in stages is that I saved the scenario file when all the python was loaded and then just removed all the unwanted information (like technologies) from there.
