### PR TITLE
Makes the BUG building actual effects option the default bug setting

### DIFF
--- a/UserSettings/BUG City Bar.ini
+++ b/UserSettings/BUG City Bar.ini
@@ -63,7 +63,7 @@ Base Production = True
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
 # Default: True
 
-Building Actual Effects = False
+Building Actual Effects = True
 
 # When checked, shows the cost (⇺ or ℴ) and overflow (ℤ and ℴ) for hurrying (whip and/or buy) the item being produced.
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
@@ -75,7 +75,8 @@ Hurry Assist = True
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
 # Default: False
 
-Hurry Assist Include Current = False
+Hurry Assist Include Current = False
+
 
 # When checked, shows breakdowns for trade: total, foreign, and foreign overseas. Each includes those after it: foreign includes foreign overseas, and total includes both foreign and foreign overseas.
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>

--- a/UserSettings/BUG Misc Hovers.ini
+++ b/UserSettings/BUG Misc Hovers.ini
@@ -59,7 +59,7 @@ Unit Experience Modifiers = True
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
 # Default: True
 
-Building Actual Effects = False
+Building Actual Effects = True
 [Tech]
 
 # When checked, displays the technologies that will be sped up by acquiring the technology you are hovering over (e.g. Animal Husbandry would be shown for Agriculture once you have acquired Hunting).
@@ -98,49 +98,49 @@ Great People Rate Breakdown = True
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
 # Default: True
 
-Building Saved Maintenance = False
+Building Saved Maintenance = True
 
 # When checked, displays the buildings that will affect the ℣ rate and by how much.
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
 # Default: True
 
-Building Additional Food = False
+Building Additional Food = True
 
 # When checked, displays the buildings that will affect the ℤ rate and by how much.
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
 # Default: True
 
-Building Additional Production = False
+Building Additional Production = True
 
 # When checked, displays the buildings that will affect the ℥, ℴ, ℵ, ℶ, and ℷ rates and by how much.
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
 # Default: True
 
-Building Additional Commerce = False
+Building Additional Commerce = True
 
 # When checked, displays the buildings that will affect the ⇥ and ⇦ rates and by how much.
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
 # Default: True
 
-Building Additional Health = False
+Building Additional Health = True
 
 # When checked, displays the buildings that will affect the ⇣ and ⇤ rates and by how much.
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
 # Default: True
 
-Building Additional Happiness = False
+Building Additional Happiness = True
 
 # When checked, displays the buildings that will affect the ⇯ rate and by how much.
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
 # Default: True
 
-Building Additional Great People = False
+Building Additional Great People = True
 
 # When checked, displays the buildings that will affect the ⇮ of the city and from bombardment and by how much.
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
 # Default: True
 
-Building Additional Defense = False
+Building Additional Defense = True
 [Action Buttons]
 
 # When checked, displays the full details of the unit that will be drafted in the Draft button hover.
@@ -181,4 +181,5 @@ CDA Zoom City Details = True
 
 # When checked, the Zoom to City button includes detailed information about the city as when hovering over a city bar on the map.
 # <color=255,76,76,255>This feature requires the BUG DLL (BULL).</color>
-# Default: True
+# Default: True
+


### PR DESCRIPTION
I have a feeling that most players use this or would if they knew about it. I could do a poll on civ fanatics if you want to determine if it should be the default option.

The Files changed section is displaying 100% wrong I don't know why. I just changed all the Building Actual Effects options to true.
