### PR TITLE
New options

### DIFF
--- a/Assets/Python/BUG/WidgetUtil.py
+++ b/Assets/Python/BUG/WidgetUtil.py
@@ -144,7 +144,20 @@ def getWidgetHelp(argsList):
 		if iData1 == 1027:
 			return CyTranslator().getText("TXT_KEY_WB_PLOT_DATA",())
 		elif iData1 == 1028:
-			return gc.getGameOptionInfo(iData2).getHelp()
+			if iData2 < gc.getNumGameOptionInfos():
+				return gc.getGameOptionInfo(iData2).getHelp()
+			elif iData2 < 2000:
+				return CyTranslator().getText("TXT_KEY_WB_OPTIONS_ENABLE_CIV",())
+			elif iData2 == 2000:
+				return CyTranslator().getText("TXT_KEY_WB_NO_STABILITY_TEXT",())
+			elif iData2 == 2001:
+				return CyTranslator().getText("TXT_KEY_WB_NO_HUMAN_STABILITY_TEXT",())
+			elif iData2 == 2002:
+				return CyTranslator().getText("TXT_KEY_WB_IGNORE_AI_UHV_TEXT",())
+			elif iData2 == 2003:
+				return CyTranslator().getText("TXT_KEY_WB_UNLIMITED_SWITCHING_TEXT",())
+			elif iData2 == 2004:
+				return CyTranslator().getText("TXT_KEY_WB_ALREADY_SWITCHED_TEXT",())
 		elif iData1 == 1029:
 			if iData2 == 0:
 				sText = CyTranslator().getText("TXT_KEY_WB_PYTHON", ())

--- a/Assets/Python/BUG/WidgetUtil.py
+++ b/Assets/Python/BUG/WidgetUtil.py
@@ -149,15 +149,21 @@ def getWidgetHelp(argsList):
 			elif iData2 < 2000:
 				return CyTranslator().getText("TXT_KEY_WB_OPTIONS_ENABLE_CIV",())
 			elif iData2 == 2000:
-				return CyTranslator().getText("TXT_KEY_WB_NO_STABILITY_TEXT",())
+				return CyTranslator().getText("TXT_KEY_WB_NO_STABILITY_HELP",())
 			elif iData2 == 2001:
-				return CyTranslator().getText("TXT_KEY_WB_NO_HUMAN_STABILITY_TEXT",())
+				return CyTranslator().getText("TXT_KEY_WB_NO_HUMAN_STABILITY_HELP",())
 			elif iData2 == 2002:
-				return CyTranslator().getText("TXT_KEY_WB_IGNORE_AI_UHV_TEXT",())
+				return CyTranslator().getText("TXT_KEY_WB_IGNORE_AI_UHV_HELP",())
 			elif iData2 == 2003:
-				return CyTranslator().getText("TXT_KEY_WB_UNLIMITED_SWITCHING_TEXT",())
+				return CyTranslator().getText("TXT_KEY_WB_UNLIMITED_SWITCHING_HELP",())
+			elif iData2 == 2004:
+				return CyTranslator().getText("TXT_KEY_WB_NO_CONGRESS_HELP",())
+			elif iData2 == 2005:
+				return CyTranslator().getText("TXT_KEY_WB_NO_PLAGUE_HELP",())
 			elif iData2 == 3001:
-				return CyTranslator().getText("TXT_KEY_WB_ALREADY_SWITCHED_TEXT",())
+				return CyTranslator().getText("TXT_KEY_WB_ALREADY_SWITCHED_HELP",())
+			elif iData2 == 3002:
+				return CyTranslator().getText("TXT_KEY_WB_CONGRESS_TURNS_HELP",())
 		elif iData1 == 1029:
 			if iData2 == 0:
 				sText = CyTranslator().getText("TXT_KEY_WB_PYTHON", ())

--- a/Assets/Python/BUG/WidgetUtil.py
+++ b/Assets/Python/BUG/WidgetUtil.py
@@ -156,7 +156,7 @@ def getWidgetHelp(argsList):
 				return CyTranslator().getText("TXT_KEY_WB_IGNORE_AI_UHV_TEXT",())
 			elif iData2 == 2003:
 				return CyTranslator().getText("TXT_KEY_WB_UNLIMITED_SWITCHING_TEXT",())
-			elif iData2 == 2004:
+			elif iData2 == 3001:
 				return CyTranslator().getText("TXT_KEY_WB_ALREADY_SWITCHED_TEXT",())
 		elif iData1 == 1029:
 			if iData2 == 0:

--- a/Assets/Python/Congresses.py
+++ b/Assets/Python/Congresses.py
@@ -65,6 +65,9 @@ def onChangeWar(bWar, iPlayer, iOtherPlayer):
 ### Global Methods ###
 
 def isCongressEnabled():
+	if sd.isNoCongressOption():
+		return False
+
 	if gc.getGame().getBuildingClassCreatedCount(gc.getBuildingInfo(iUnitedNations).getBuildingClassType()) > 0:
 		return False
 		

--- a/Assets/Python/Plague.py
+++ b/Assets/Python/Plague.py
@@ -32,31 +32,6 @@ iImmunity = con.iImmunity
 
 class Plague:
 
-
-##################################################
-### Secure storage & retrieval of script data ###
-################################################   
-
-
-	def getPlagueCountdown( self, iCiv ):
-		return sd.scriptDict['lPlagueCountdown'][iCiv]
-
-	def setPlagueCountdown( self, iCiv, iNewValue ):
-		sd.scriptDict['lPlagueCountdown'][iCiv] = iNewValue
-
-	def getGenericPlagueDates( self, i ):
-		return sd.scriptDict['lGenericPlagueDates'][i]
-
-	def setGenericPlagueDates( self, i, iNewValue ):
-		sd.scriptDict['lGenericPlagueDates'][i] = iNewValue
-		
-	def getFirstContactPlague( self, iCiv ):
-		return sd.scriptDict['lFirstContactPlague'][iCiv]
-
-	def setFirstContactPlague( self, iCiv, bNewValue ):
-		sd.scriptDict['lFirstContactPlague'][iCiv] = bNewValue
-
-
 #######################################
 ### Main methods (Event-Triggered) ###
 #####################################  
@@ -65,67 +40,71 @@ class Plague:
 	def setup(self):
 
 		for i in range(iNumMajorPlayers):
-			self.setPlagueCountdown(i, -utils.getTurns(iImmunity)) 
-##		self.setGenericPlagueDates(0, 100 + gc.getGame().getSorenRandNum(30, 'Variation') - 15) #-400 ca
-##		self.setGenericPlagueDates(1, 150 + gc.getGame().getSorenRandNum(30, 'Variation') - 15) #600 ca
-##		self.setGenericPlagueDates(2, 225 + gc.getGame().getSorenRandNum(30, 'Variation') - 15) #1340
-##		self.setGenericPlagueDates(3, 277 + gc.getGame().getSorenRandNum(30, 'Variation') - 15) #1630
-##		self.setGenericPlagueDates(4, 340 + gc.getGame().getSorenRandNum(30, 'Variation') - 15) #1850 ca
+			sd.setPlagueCountdown(i, -utils.getTurns(iImmunity)) 
+##		sd.setGenericPlagueDates(0, 100 + gc.getGame().getSorenRandNum(30, 'Variation') - 15) #-400 ca
+##		sd.setGenericPlagueDates(1, 150 + gc.getGame().getSorenRandNum(30, 'Variation') - 15) #600 ca
+##		sd.setGenericPlagueDates(2, 225 + gc.getGame().getSorenRandNum(30, 'Variation') - 15) #1340
+##		sd.setGenericPlagueDates(3, 277 + gc.getGame().getSorenRandNum(30, 'Variation') - 15) #1630
+##		sd.setGenericPlagueDates(4, 340 + gc.getGame().getSorenRandNum(30, 'Variation') - 15) #1850 ca
 		if utils.getScenario() == con.i3000BC:  #late start condition
-			self.setGenericPlagueDates(0, getTurnForYear(400) + gc.getGame().getSorenRandNum(40, 'Variation') - 20) #turn 170
+			sd.setGenericPlagueDates(0, getTurnForYear(400) + gc.getGame().getSorenRandNum(40, 'Variation') - 20) #turn 170
 		else:
-			self.setGenericPlagueDates(0, 80) #safe value
-		self.setGenericPlagueDates(1, getTurnForYear(1300) + gc.getGame().getSorenRandNum(40, 'Variation') - 20) #turn 250
-		self.setGenericPlagueDates(2, getTurnForYear(1650) + gc.getGame().getSorenRandNum(40, 'Variation') - 20) #turn 315
-		self.setGenericPlagueDates(3, getTurnForYear(1850) + gc.getGame().getSorenRandNum(40, 'Variation') - 20) #turn 380
+			sd.setGenericPlagueDates(0, 80) #safe value
+		sd.setGenericPlagueDates(1, getTurnForYear(1300) + gc.getGame().getSorenRandNum(40, 'Variation') - 20) #turn 250
+		sd.setGenericPlagueDates(2, getTurnForYear(1650) + gc.getGame().getSorenRandNum(40, 'Variation') - 20) #turn 315
+		sd.setGenericPlagueDates(3, getTurnForYear(1850) + gc.getGame().getSorenRandNum(40, 'Variation') - 20) #turn 380
 
 		undoPlague = gc.getGame().getSorenRandNum(8, 'undo')
 		if (undoPlague <= 3):
-			self.setGenericPlagueDates(undoPlague, -1)
+			sd.setGenericPlagueDates(undoPlague, -1)
 
 
 	def checkTurn(self, iGameTurn):
+		if sd.isNoPlagueOption():
+			return
 
 		for i in range(iNumTotalPlayersB):
 			if (gc.getPlayer(i).isAlive()):
-				if (self.getPlagueCountdown(i) > 0):
-					self.setPlagueCountdown(i, self.getPlagueCountdown(i)-1)
-					#print ("plague countdown", i, self.getPlagueCountdown(i))
-					if (self.getPlagueCountdown(i) == 2):
+				if (sd.getPlagueCountdown(i) > 0):
+					sd.setPlagueCountdown(i, sd.getPlagueCountdown(i)-1)
+					#print ("plague countdown", i, sd.getPlagueCountdown(i))
+					if (sd.getPlagueCountdown(i) == 2):
 						self.preStopPlague(i)
-					if (self.getPlagueCountdown(i) == 0):
+					if (sd.getPlagueCountdown(i) == 0):
 						self.stopPlague(i)
-				elif (self.getPlagueCountdown(i) < 0):
-					self.setPlagueCountdown(i, self.getPlagueCountdown(i)+1)
+				elif (sd.getPlagueCountdown(i) < 0):
+					sd.setPlagueCountdown(i, sd.getPlagueCountdown(i)+1)
 
 		for i in range(4):
-			if (iGameTurn == self.getGenericPlagueDates(i)):
+			if (iGameTurn == sd.getGenericPlagueDates(i)):
 				#print ("new plague")
 				self.startPlague(i)
 			if (i >= 1):
 				#retry if the epidemic is dead too quickly
-				if (iGameTurn == self.getGenericPlagueDates(i) + 4):
+				if (iGameTurn == sd.getGenericPlagueDates(i) + 4):
 					iInfectedCounter = 0
 					for j in range(iNumTotalPlayersB):
-						if (self.getPlagueCountdown(j) > 0):
+						if (sd.getPlagueCountdown(j) > 0):
 							iInfectedCounter += 1
 					if (iInfectedCounter == 1):
 						#print ("new plague again1")
 						self.startPlague(i)
 			if (i == 2 or i == 3):
-				if (iGameTurn == self.getGenericPlagueDates(i) + 8):
+				if (iGameTurn == sd.getGenericPlagueDates(i) + 8):
 					iInfectedCounter = 0
 					for j in range(iNumTotalPlayersB):
-						if (self.getPlagueCountdown(j) > 0):
+						if (sd.getPlagueCountdown(j) > 0):
 							iInfectedCounter += 1
 					if (iInfectedCounter <= 2):
 						#print ("new plague again2")
 						self.startPlague(i)
 
 	def checkPlayerTurn(self, iGameTurn, iPlayer):
+		if sd.isNoPlagueOption():
+			return
 
 		if (iPlayer < iNumTotalPlayersB):
-			if (self.getPlagueCountdown(iPlayer) > 0):
+			if (sd.getPlagueCountdown(iPlayer) > 0):
 				self.processPlague(iPlayer)
 
 
@@ -182,10 +161,10 @@ class Plague:
 
 	def stopPlague(self, iPlayer):
 
-		self.setPlagueCountdown(iPlayer, -utils.getTurns(iImmunity))
-		if (self.getFirstContactPlague(iPlayer) == True):
-			self.setPlagueCountdown(iPlayer, -utils.getTurns(iImmunity-30))
-		self.setFirstContactPlague(iPlayer, False)
+		sd.setPlagueCountdown(iPlayer, -utils.getTurns(iImmunity))
+		if (sd.getFirstContactPlague(iPlayer) == True):
+			sd.setPlagueCountdown(iPlayer, -utils.getTurns(iImmunity-30))
+		sd.setFirstContactPlague(iPlayer, False)
 		apCityList = PyPlayer(iPlayer).getCityList()
 		for pCity in apCityList:
 			city = pCity.GetCy()
@@ -210,14 +189,14 @@ class Plague:
 					if (gc.getGame().getSorenRandNum(100, 'roll') > 40 + 5*city.healthRate(False, 0)):
 						city.changePopulation(-1)
 				if (city.isCapital()): #delete in vanilla
-					if (self.getFirstContactPlague(iPlayer) == False): #don't infect if first contact plague
+					if (sd.getFirstContactPlague(iPlayer) == False): #don't infect if first contact plague
 						for iLoopCiv in range(iNumMajorPlayers):
 							if (gc.getTeam(pPlayer.getTeam()).isVassal(iLoopCiv) or \
 							    gc.getTeam(gc.getPlayer(iLoopCiv).getTeam()).isVassal(iPlayer)):
 								if (gc.getPlayer(iLoopCiv).getNumCities() > 0): #this check is needed, otherwise game crashes
 									capital = gc.getPlayer(iLoopCiv).getCapitalCity()
 									if (self.isVulnerable(iLoopCiv) == True):
-										if (self.getPlagueCountdown(iPlayer) > 2): #don't spread the last turns
+										if (sd.getPlagueCountdown(iPlayer) > 2): #don't spread the last turns
 											self.spreadPlague(iLoopCiv)
 											self.infectCity(capital)
 											#print ("infect master/vassal", city.getName(), "to", capital.getName())
@@ -226,8 +205,8 @@ class Plague:
 						##print ("plagueXY", x, y)
 						pCurrent = gc.getMap().plot( x, y )
 						if (pCurrent.getOwner() != iPlayer and pCurrent.getOwner() >= 0):
-							if (self.getFirstContactPlague(iPlayer) == False): #don't infect if first contact plague
-								if (self.getPlagueCountdown(iPlayer) > 2): #don't spread the last turns
+							if (sd.getFirstContactPlague(iPlayer) == False): #don't infect if first contact plague
+								if (sd.getPlagueCountdown(iPlayer) > 2): #don't spread the last turns
 									if (self.isVulnerable(pCurrent.getOwner()) == True):
 										self.spreadPlague(pCurrent.getOwner())
 										self.infectCitiesNear(pCurrent.getOwner(), x, y)
@@ -237,7 +216,7 @@ class Plague:
 								#print ("is city", x, y)
 								cityNear = pCurrent.getPlotCity() 
 								if (not cityNear.hasBuilding(iPlague)):
-									if (self.getPlagueCountdown(iPlayer) > 2): #don't spread the last turns
+									if (sd.getPlagueCountdown(iPlayer) > 2): #don't spread the last turns
 										self.infectCity(cityNear)
 										#print ("infect near", city.getName(), "to", cityNear.getName())
 							else:
@@ -274,9 +253,9 @@ class Plague:
 								self.killUnitsByPlague(city, pCurrent, 30, 35, 0)
 
 
-				if (self.getFirstContactPlague(iPlayer) == False): #don't infect if first contact plague
+				if (sd.getFirstContactPlague(iPlayer) == False): #don't infect if first contact plague
 					#spread to trade route cities
-					if (self.getPlagueCountdown(iPlayer) > 2): #don't spread the last turns
+					if (sd.getPlagueCountdown(iPlayer) > 2): #don't spread the last turns
 						for i in range(city.getTradeRoutes()):
 						#for i in range(gc.getDefineINT("MAX_TRADE_ROUTES")):
 							loopCity = city.getTradeCity(i)
@@ -301,7 +280,7 @@ class Plague:
 
 		#spread to other cities of the empire
 		if (len(cityList)):
-			if (self.getPlagueCountdown(iPlayer) > 2): #don't spread the last turns
+			if (sd.getPlagueCountdown(iPlayer) > 2): #don't spread the last turns
 				for city1 in cityList:
 					##print ("citylist", city1.getName())
 					if (not city1.hasBuilding(iPlague)):
@@ -386,7 +365,7 @@ class Plague:
 							iDamage *= 3
 							iDamage /= 4
 					
-					if (self.getFirstContactPlague(city.getOwner()) == True):
+					if (sd.getFirstContactPlague(city.getOwner()) == True):
 						if (unit.getOwner() in con.lCivBioOldWorld):
 							iDamage /= 2
 					
@@ -431,12 +410,12 @@ class Plague:
 
 	def isVulnerable(self, iPlayer):
 		if (iPlayer >= iNumMajorPlayers):
-			if (self.getPlagueCountdown(iPlayer) <= 0 and self.getPlagueCountdown(iPlayer) > -10 ): #more vulnerable
+			if (sd.getPlagueCountdown(iPlayer) <= 0 and sd.getPlagueCountdown(iPlayer) > -10 ): #more vulnerable
 				return True
 		else:
 			pPlayer = gc.getPlayer(iPlayer)
-			if (self.getPlagueCountdown(iPlayer) == 0): #vulnerable
-			#if (self.getPlagueCountdown(iPlayer) < 0): #debug
+			if (sd.getPlagueCountdown(iPlayer) == 0): #vulnerable
+			#if (sd.getPlagueCountdown(iPlayer) < 0): #debug
 				if (not gc.getTeam(pPlayer.getTeam()).isHasTech(con.iMedicine)):
 					iHealth = -30
 					if (pPlayer.calculateTotalCityHealthiness() > 0):
@@ -457,7 +436,7 @@ class Plague:
 			iHealth = int((1.0 * pPlayer.calculateTotalCityHealthiness()) / (pPlayer.calculateTotalCityHealthiness() + \
 				pPlayer.calculateTotalCityUnhealthiness()) * 100) - 60
 		iHealth /= 7 #duration range will be -4 to +4 for 30 to 90
-		self.setPlagueCountdown(iPlayer, min(9,iDuration - iHealth))
+		sd.setPlagueCountdown(iPlayer, min(9,iDuration - iHealth))
 		print ("spreading plague to", iPlayer)
 
 
@@ -476,8 +455,8 @@ class Plague:
 
 	def onCityAcquired(self, iOldOwner, iNewOwner, city):
 		if (city.hasBuilding(iPlague)):
-			if (self.getFirstContactPlague(iOldOwner) == False): #don't infect if first contact plague
-				if (self.getPlagueCountdown(iNewOwner) <= 0 and gc.getGame().getGameTurn() > getTurnForYear(con.tBirth[iNewOwner]) + utils.getTurns(iImmunity) ): #skip immunity in this case (to prevent expoiting of being immune to conquer weak civs), but not for the new born civs
+			if (sd.getFirstContactPlague(iOldOwner) == False): #don't infect if first contact plague
+				if (sd.getPlagueCountdown(iNewOwner) <= 0 and gc.getGame().getGameTurn() > getTurnForYear(con.tBirth[iNewOwner]) + utils.getTurns(iImmunity) ): #skip immunity in this case (to prevent expoiting of being immune to conquer weak civs), but not for the new born civs
 					if (not gc.getTeam(gc.getPlayer(iNewOwner).getTeam()).isHasTech(con.iMedicine)): #but not permanent immunity
 						print("acquiring plague")
 						self.spreadPlague(iNewOwner)
@@ -491,7 +470,7 @@ class Plague:
 
 	def onCityRazed(self, city, iNewOwner):
 		if (city.hasBuilding(iPlague)):
-			if (self.getPlagueCountdown(iNewOwner) > 0):
+			if (sd.getPlagueCountdown(iNewOwner) > 0):
 				apCityList = PyPlayer(iNewOwner).getCityList()
 				iNumCitiesInfected = 0
 				for pCity in apCityList:
@@ -501,10 +480,13 @@ class Plague:
 							iNumCitiesInfected += 1
 				print ("iNumCitiesInfected", iNumCitiesInfected)
 				if (iNumCitiesInfected == 0):
-					self.setPlagueCountdown(iNewOwner, 0) #undo spreadPlague called in onCityAcquired()
+					sd.setPlagueCountdown(iNewOwner, 0) #undo spreadPlague called in onCityAcquired()
 
 
 	def onFirstContact(self, iTeamX, iHasMetTeamY):
+		if sd.isNoPlagueOption():
+			return
+
 		if (gc.getGame().getGameTurn() > getTurnForYear(con.tBirth[con.iAztecs]) + 2 and gc.getGame().getGameTurn() < getTurnForYear(1800)):
 			iOldWorldCiv = -1
 			iNewWorldCiv = -1
@@ -516,7 +498,7 @@ class Plague:
 				iOldWorldCiv = iHasMetTeamY
 			if (iOldWorldCiv != -1 and iNewWorldCiv != -1):
 				pNewWorldCiv = gc.getPlayer(iNewWorldCiv)
-				if (self.getPlagueCountdown(iNewWorldCiv) == 0): #vulnerable
+				if (sd.getPlagueCountdown(iNewWorldCiv) == 0): #vulnerable
 					#print ("vulnerable", iNewWorldCiv)
 					if (not gc.getTeam(pNewWorldCiv.getTeam()).isHasTech(con.iBiology)):
 						city = utils.getRandomCity(iNewWorldCiv)
@@ -528,8 +510,8 @@ class Plague:
 							if (iHealth < 10): #no spread for iHealth >= 70 years
 								iHealth /= 10
 								if (gc.getGame().getSorenRandNum(100, 'roll') > 30 + 5*iHealth):
-									self.setPlagueCountdown(iNewWorldCiv, iDuration - iHealth)
-									self.setFirstContactPlague(iNewWorldCiv, True)
+									sd.setPlagueCountdown(iNewWorldCiv, iDuration - iHealth)
+									sd.setFirstContactPlague(iNewWorldCiv, True)
 									#print ("spreading (through first contact) plague to", iNewWorldCiv)
 									self.infectCity(city)
 									iHuman = utils.getHumanID()
@@ -538,5 +520,5 @@ class Plague:
 
 
 	def onTechAcquired(self, iTech, iPlayer):
-		if (self.getPlagueCountdown(iPlayer) > 1):
-			self.setPlagueCountdown(iPlayer, 1)
+		if (sd.getPlagueCountdown(iPlayer) > 1):
+			sd.setPlagueCountdown(iPlayer, 1)

--- a/Assets/Python/RFCUtils.py
+++ b/Assets/Python/RFCUtils.py
@@ -85,11 +85,6 @@ class RFCUtils:
 	def getTempEventList( self ):
 		return sd.scriptDict['lTempEventList']
 		
-	def setPlayerEnabled(self, iCiv, bNewValue):
-		sd.scriptDict['lPlayerEnabled'][con.lSecondaryCivs.index(iCiv)] = bNewValue
-		
-	def getPlayerEnabled(self, iCiv):
-		return sd.scriptDict['lPlayerEnabled'][con.lSecondaryCivs.index(iCiv)]
 
 #######################################
 			    

--- a/Assets/Python/Resources.py
+++ b/Assets/Python/Resources.py
@@ -6,6 +6,7 @@ import PyHelpers
 #import Popup
 import Consts as con
 import RFCUtils # edead
+from StoredData import sd
 
 # globals
 gc = CyGlobalContext()
@@ -82,7 +83,7 @@ class Resources:
 			self.createResource(88, 37, iHorse)
 			
 		# Tamils
-		if iGameTurn == getTurnForYear(-300)-1 and utils.getPlayerEnabled(con.iTamils):
+		if iGameTurn == getTurnForYear(-300)-1 and sd.isPlayerEnabled(con.iTamils):
 			self.createResource(90, 28, iFish)
 
 		#Orka: Silk Road
@@ -151,7 +152,7 @@ class Resources:
 		#	CyGame().setPlotExtraYield(89, 46, YieldTypes.YIELD_FOOD, 2) #Kashgar
 			
 		# Leoreth: prepare Tibet
-		if iGameTurn == getTurnForYear(630)-1 and utils.getPlayerEnabled(con.iTibet):
+		if iGameTurn == getTurnForYear(630)-1 and sd.isPlayerEnabled(con.iTibet):
 			self.createResource(95, 43, iWheat)
 			self.createResource(97, 44, iHorse)
 			
@@ -183,7 +184,7 @@ class Resources:
 			self.createResource(66, 23, iBanana) # Central Africa
 			self.createResource(64, 20, iBanana) # Central Africa
 			
-			if utils.getPlayerEnabled(con.iCongo):
+			if sd.isPlayerEnabled(con.iCongo):
 				self.createResource(61, 22, iCotton) # Congo
 				self.createResource(63, 19, iIvory) # Congo
 				self.createResource(61, 24, iIvory) # Cameroon
@@ -309,12 +310,12 @@ class Resources:
 			if gc.getDefineINT("PLAYER_REBIRTH_COLOMBIA") != 0:
 				self.createResource(28, 31, iIron) # Colombia
 			
-			if utils.getPlayerEnabled(con.iArgentina):
+			if sd.isPlayerEnabled(con.iArgentina):
 				self.createResource(31, 10, iWine) # Mendoza, Argentina
 				self.createResource(31, 6, iSheep) # Pampas, Argentina
 				self.createResource(32, 11, iIron) # Argentina
 			
-			if utils.getPlayerEnabled(con.iBrazil):
+			if sd.isPlayerEnabled(con.iBrazil):
 				self.createResource(36, 18, iCorn) # Sao Paulo
 				self.createResource(42, 18, iFish) # Rio de Janeiro
 

--- a/Assets/Python/RiseAndFall.py
+++ b/Assets/Python/RiseAndFall.py
@@ -1475,7 +1475,7 @@ class RiseAndFall:
 		iBirthYear = getTurnForYear(iBirthYear) # converted to turns here - edead
 		
 		if iCiv in lSecondaryCivs:
-			if iHuman != iCiv and not sd.getPlayerEnabled(iCiv):
+			if iHuman != iCiv and not sd.isPlayerEnabled(iCiv):
 				return
 		
 		if iCiv == iTurkey:
@@ -1675,7 +1675,7 @@ class RiseAndFall:
 		if iCiv in [iByzantium, iArgentina, iBrazil]:
 			self.setStateReligion(iCiv)
 			
-		if (iCurrentTurn == iBirthYear + self.getSpawnDelay(iCiv)) and (gc.getPlayer(iCiv).isAlive()) and (sd.getAlreadySwitched() == False or utils.getReborn(iCiv) == 1 or sd.getUnlimitedSwitching() == True) and ((iHuman not in lNeighbours[iCiv] and getTurnForYear(tBirth[iCiv]) - getTurnForYear(tBirth[iHuman]) > 0) or getTurnForYear(tBirth[iCiv]) - getTurnForYear(tBirth[iHuman]) >= utils.getTurns(25) ):
+		if (iCurrentTurn == iBirthYear + self.getSpawnDelay(iCiv)) and (gc.getPlayer(iCiv).isAlive()) and (sd.isAlreadySwitched() == False or utils.getReborn(iCiv) == 1 or sd.isUnlimitedSwitching() == True) and ((iHuman not in lNeighbours[iCiv] and getTurnForYear(tBirth[iCiv]) - getTurnForYear(tBirth[iHuman]) > 0) or getTurnForYear(tBirth[iCiv]) - getTurnForYear(tBirth[iHuman]) >= utils.getTurns(25) ):
 			self.newCivPopup(iCiv)
 
 	def moveOutInvaders(self, tTL, tBR):
@@ -3070,7 +3070,7 @@ class RiseAndFall:
 			utils.makeUnit(iLongbowman, iCiv, tPlot, 1)
 			utils.makeUnitAI(iLongbowman, iCiv, tPlot, UnitAITypes.UNITAI_CITY_DEFENSE, 1)
 			utils.makeUnit(iSwordsman, iCiv, tPlot, 4)
-			if sd.getPlayerEnabled(iMoors):
+			if sd.isPlayerEnabled(iMoors):
 				if utils.getHumanID() != iMoors:
 					utils.makeUnit(iKnight, iCiv, tPlot, 2)
 			else:
@@ -3515,7 +3515,7 @@ class RiseAndFall:
 				utils.makeUnit(iSettler, iPlayer, tCapital, 1)
 				utils.makeUnit(iWarrior, iPlayer, tCapital, 1)
 				
-			if iPlayer == iHarappa and (sd.getPlayerEnabled(iPlayer) or gc.getPlayer(iPlayer).isHuman()):
+			if iPlayer == iHarappa and (sd.isPlayerEnabled(iPlayer) or gc.getPlayer(iPlayer).isHuman()):
 				utils.makeUnit(iHarappanCityBuilder, iPlayer, tCapital, 1)
 				utils.makeUnit(iWarrior, iPlayer, tCapital, 1)
 		

--- a/Assets/Python/RiseAndFall.py
+++ b/Assets/Python/RiseAndFall.py
@@ -85,12 +85,6 @@ class RiseAndFall:
 	def setSpawnWar( self, iNewValue ):
 		sd.scriptDict['iSpawnWar'] = iNewValue
 
-	def getAlreadySwitched( self ):
-		return sd.scriptDict['bAlreadySwitched']
-
-	def setAlreadySwitched( self, bNewValue ):
-		sd.scriptDict['bAlreadySwitched'] = bNewValue
-
 	def getColonistsAlreadyGiven( self, iCiv ):
 		return sd.scriptDict['lColonistsAlreadyGiven'][iCiv]
 
@@ -204,13 +198,6 @@ class RiseAndFall:
 		lMongolCivs = [iPersia, iByzantium, iArabia, iRussia, iMughals]
 		return sd.scriptDict['lFirstContactMongols'][lMongolCivs.index(iCiv)]
 		
-	def setPlayerEnabled(self, iCiv, bNewValue):
-		sd.scriptDict['lPlayerEnabled'][lSecondaryCivs.index(iCiv)] = bNewValue
-		if bNewValue == False and utils.getHumanID() != iCiv: gc.getPlayer(iCiv).setPlayable(False)
-		
-	def getPlayerEnabled(self, iCiv):
-		return sd.scriptDict['lPlayerEnabled'][lSecondaryCivs.index(iCiv)]
-		
 ###############
 ### Popups ###
 #############
@@ -250,7 +237,7 @@ class RiseAndFall:
 		for iMaster in range(iNumPlayers):
 			if (gc.getTeam(gc.getPlayer(iCiv).getTeam()).isVassal(iMaster)):
 				gc.getTeam(gc.getPlayer(iCiv).getTeam()).setVassal(iMaster, False, False)
-		self.setAlreadySwitched(True)
+		sd.setAlreadySwitched(True)
 		gc.getPlayer(iCiv).setPlayable(True)
 		
 		sd.resetHumanStability()
@@ -473,6 +460,19 @@ class RiseAndFall:
 		self.invalidateUHVs()
 		
 		gc.getGame().setVoteSourceReligion(1, iCatholicism, False)
+		
+		self.updateExtraOptions()
+		
+	def updateExtraOptions(self):
+		# Human player can't collapse
+		bNoHumanStability = (gc.getDefineINT("NO_HUMAN_STABILITY") != 0)
+		sd.setNoHumanStability(bNoHumanStability)
+		# No stability checks at all
+		bNoAIStability = (gc.getDefineINT("NO_STABILITY") != 0)
+		sd.setNoStability(bNoAIStability)
+		# Human player can switch infinite times
+		bUnlimitedSwitching = (gc.getDefineINT("UNLIMITED_SWITCHING") != 0)
+		sd.setUnlimitedSwitching(bUnlimitedSwitching)
 		
 	def updateStartingPlots(self):
 		for iPlayer in range(iNumPlayers):
@@ -1475,7 +1475,7 @@ class RiseAndFall:
 		iBirthYear = getTurnForYear(iBirthYear) # converted to turns here - edead
 		
 		if iCiv in lSecondaryCivs:
-			if iHuman != iCiv and not self.getPlayerEnabled(iCiv):
+			if iHuman != iCiv and not sd.getPlayerEnabled(iCiv):
 				return
 		
 		if iCiv == iTurkey:
@@ -1675,7 +1675,7 @@ class RiseAndFall:
 		if iCiv in [iByzantium, iArgentina, iBrazil]:
 			self.setStateReligion(iCiv)
 			
-		if (iCurrentTurn == iBirthYear + self.getSpawnDelay(iCiv)) and (gc.getPlayer(iCiv).isAlive()) and (self.getAlreadySwitched() == False or utils.getReborn(iCiv) == 1) and ((iHuman not in lNeighbours[iCiv] and getTurnForYear(tBirth[iCiv]) - getTurnForYear(tBirth[iHuman]) > 0) or getTurnForYear(tBirth[iCiv]) - getTurnForYear(tBirth[iHuman]) >= utils.getTurns(25) ):
+		if (iCurrentTurn == iBirthYear + self.getSpawnDelay(iCiv)) and (gc.getPlayer(iCiv).isAlive()) and (sd.getAlreadySwitched() == False or utils.getReborn(iCiv) == 1 or sd.getUnlimitedSwitching() == True) and ((iHuman not in lNeighbours[iCiv] and getTurnForYear(tBirth[iCiv]) - getTurnForYear(tBirth[iHuman]) > 0) or getTurnForYear(tBirth[iCiv]) - getTurnForYear(tBirth[iHuman]) >= utils.getTurns(25) ):
 			self.newCivPopup(iCiv)
 
 	def moveOutInvaders(self, tTL, tBR):
@@ -3070,7 +3070,7 @@ class RiseAndFall:
 			utils.makeUnit(iLongbowman, iCiv, tPlot, 1)
 			utils.makeUnitAI(iLongbowman, iCiv, tPlot, UnitAITypes.UNITAI_CITY_DEFENSE, 1)
 			utils.makeUnit(iSwordsman, iCiv, tPlot, 4)
-			if self.getPlayerEnabled(iMoors):
+			if sd.getPlayerEnabled(iMoors):
 				if utils.getHumanID() != iMoors:
 					utils.makeUnit(iKnight, iCiv, tPlot, 2)
 			else:
@@ -3515,7 +3515,7 @@ class RiseAndFall:
 				utils.makeUnit(iSettler, iPlayer, tCapital, 1)
 				utils.makeUnit(iWarrior, iPlayer, tCapital, 1)
 				
-			if iPlayer == iHarappa and (self.getPlayerEnabled(iPlayer) or gc.getPlayer(iPlayer).isHuman()):
+			if iPlayer == iHarappa and (sd.getPlayerEnabled(iPlayer) or gc.getPlayer(iPlayer).isHuman()):
 				utils.makeUnit(iHarappanCityBuilder, iPlayer, tCapital, 1)
 				utils.makeUnit(iWarrior, iPlayer, tCapital, 1)
 		
@@ -3616,71 +3616,71 @@ class RiseAndFall:
 		
 		iRand = gc.getDefineINT("PLAYER_OCCURRENCE_POLYNESIA")	
 		if iRand <= 0:
-			self.setPlayerEnabled(iPolynesia, False)
+			sd.setPlayerEnabled(iPolynesia, False)
 		elif gc.getGame().getSorenRandNum(iRand, 'Polynesia enabled?') != 0:
-			self.setPlayerEnabled(iPolynesia, False)
+			sd.setPlayerEnabled(iPolynesia, False)
 			
 		iRand = gc.getDefineINT("PLAYER_OCCURRENCE_HARAPPA")
 		if iRand <= 0:
-			self.setPlayerEnabled(iHarappa, False)
+			sd.setPlayerEnabled(iHarappa, False)
 		elif gc.getGame().getSorenRandNum(iRand, 'Harappa enabled?') != 0:
-			self.setPlayerEnabled(iHarappa, False)
+			sd.setPlayerEnabled(iHarappa, False)
 		
 		if iHuman != iIndia and iHuman != iIndonesia:
 			iRand = gc.getDefineINT("PLAYER_OCCURRENCE_TAMILS")
 			
 			if iRand <= 0:
-				self.setPlayerEnabled(iTamils, False)
+				sd.setPlayerEnabled(iTamils, False)
 			elif gc.getGame().getSorenRandNum(iRand, 'Tamils enabled?') != 0:
-				self.setPlayerEnabled(iTamils, False)
+				sd.setPlayerEnabled(iTamils, False)
 				
 		if iHuman != iChina and iHuman != iIndia and iHuman != iMughals:
 			iRand = gc.getDefineINT("PLAYER_OCCURRENCE_TIBET")
 			
 			if iRand <= 0:
-				self.setPlayerEnabled(iTibet, False)
+				sd.setPlayerEnabled(iTibet, False)
 			elif gc.getGame().getSorenRandNum(iRand, 'Tibet enabled?') != 0:
-				self.setPlayerEnabled(iTibet, False)
+				sd.setPlayerEnabled(iTibet, False)
 				
 		if iHuman != iSpain and iHuman != iMali:
 			iRand = gc.getDefineINT("PLAYER_OCCURRENCE_MOORS")
 			
 			if iRand <= 0:
-				self.setPlayerEnabled(iMoors, False)
+				sd.setPlayerEnabled(iMoors, False)
 			elif gc.getGame().getSorenRandNum(iRand, 'Moors enabled?') != 0:
-				self.setPlayerEnabled(iMoors, False)
+				sd.setPlayerEnabled(iMoors, False)
 				
 		if iHuman != iHolyRome and iHuman != iGermany and iHuman != iRussia:
 			iRand = gc.getDefineINT("PLAYER_OCCURRENCE_POLAND")
 			
 			if iRand <= 0:
-				self.setPlayerEnabled(iPoland, False)
+				sd.setPlayerEnabled(iPoland, False)
 			elif gc.getGame().getSorenRandNum(iRand, 'Poland enabled?') != 0:
-				self.setPlayerEnabled(iPoland, False)
+				sd.setPlayerEnabled(iPoland, False)
 				
 		if iHuman != iMali and iHuman != iPortugal:
 			iRand = gc.getDefineINT("PLAYER_OCCURRENCE_CONGO")
 			
 			if iRand <= 0:
-				self.setPlayerEnabled(iCongo, False)
+				sd.setPlayerEnabled(iCongo, False)
 			elif gc.getGame().getSorenRandNum(iRand, 'Congo enabled?') != 0:
-				self.setPlayerEnabled(iCongo, False)
+				sd.setPlayerEnabled(iCongo, False)
 				
 		if iHuman != iSpain:
 			iRand = gc.getDefineINT("PLAYER_OCCURRENCE_ARGENTINA")
 			
 			if iRand <= 0:
-				self.setPlayerEnabled(iArgentina, False)
+				sd.setPlayerEnabled(iArgentina, False)
 			elif gc.getGame().getSorenRandNum(iRand, 'Argentina enabled?') != 0:
-				self.setPlayerEnabled(iArgentina, False)
+				sd.setPlayerEnabled(iArgentina, False)
 				
 		if iHuman != iPortugal:
 			iRand = gc.getDefineINT("PLAYER_OCCURRENCE_BRAZIL")
 			
 			if iRand <= 0:
-				self.setPlayerEnabled(iBrazil, False)
+				sd.setPlayerEnabled(iBrazil, False)
 			elif gc.getGame().getSorenRandNum(iRand, 'Brazil enabled?') != 0:
-				self.setPlayerEnabled(iBrazil, False)
+				sd.setPlayerEnabled(iBrazil, False)
 				
 	def placeHut(self, tTL, tBR):
 		plotList = []

--- a/Assets/Python/RiseAndFall.py
+++ b/Assets/Python/RiseAndFall.py
@@ -473,6 +473,12 @@ class RiseAndFall:
 		# Human player can switch infinite times
 		bUnlimitedSwitching = (gc.getDefineINT("UNLIMITED_SWITCHING") != 0)
 		sd.setUnlimitedSwitching(bUnlimitedSwitching)
+		# No congresses
+		bNoCongresses = (gc.getDefineINT("NO_CONGRESSES") != 0)
+		sd.setNoCongressOption(bNoCongresses)
+		# No plagues
+		bNoPlagues = (gc.getDefineINT("NO_PLAGUES") != 0)
+		sd.setNoPlagueOption(bNoPlagues)
 		
 	def updateStartingPlots(self):
 		for iPlayer in range(iNumPlayers):

--- a/Assets/Python/Screens/PlatyBuilder/WBGameDataScreen.py
+++ b/Assets/Python/Screens/PlatyBuilder/WBGameDataScreen.py
@@ -233,11 +233,15 @@ class WBGameDataScreen:
 		lList2.append([CyTranslator().getText("TXT_KEY_WB_NO_HUMAN_STABILITY", ()), 2001])
 		lList2.append([CyTranslator().getText("TXT_KEY_WB_IGNORE_AI_UHV", ()), 2002])
 		lList2.append([CyTranslator().getText("TXT_KEY_WB_UNLIMITED_SWITCHING", ()), 2003])
-		lList2.append([CyTranslator().getText("TXT_KEY_WB_ALREADY_SWITCHED", ()), 2004])
 		lList2.sort()
+		
+		# Stored variables
+		lList3 = []
+		lList3.append([CyTranslator().getText("TXT_KEY_WB_ALREADY_SWITCHED", ()), 3001])
+		lList3.sort()
 
 		iNumRows = (len(lList) + nColumns - 1) / nColumns
-		iNumRows2 = iNumRows + 3 + max(len(con.lSecondaryCivs), len(lList2)/2)
+		iNumRows2 = iNumRows + 3 + max(len(con.lSecondaryCivs), len(lList2), len(lList3))
 		for i in xrange(iNumRows2):
 			screen.appendTableRow("WBGameOptions")
 
@@ -259,6 +263,7 @@ class WBGameDataScreen:
 		# Merijn: extra rows for secondary civs and RFC options
 		screen.setTableText("WBGameOptions", 0, iNumRows + 2, CyTranslator().getText("TXT_KEY_WB_SECONDARY_CIVS", ()), "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY)
 		screen.setTableText("WBGameOptions", 2, iNumRows + 2, CyTranslator().getText("TXT_KEY_WB_RFC_OPTIONS", ()), "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY)
+		screen.setTableText("WBGameOptions", 4, iNumRows + 2, CyTranslator().getText("TXT_KEY_WB_RFC_VARIABLES", ()), "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY)
 
 		iRow = iNumRows + 3
 		for iCiv in con.lSecondaryCivs:
@@ -275,8 +280,7 @@ class WBGameDataScreen:
 
 		for i in xrange(len(lList2)):
 			item = lList2[i][1]
-			iColumn = i / (iNumRows2 - iNumRows) + 1
-			iRow = i % (iNumRows2 - iNumRows) + iNumRows + 3
+			iRow = iNumRows + 3 + i
 
 			bEnabled = False
 			bDefault = False
@@ -290,13 +294,23 @@ class WBGameDataScreen:
 				bDefault = True
 			elif item == 2003:
 				bEnabled = sd.getUnlimitedSwitching()
-			elif item == 2004:
-				bEnabled = sd.getAlreadySwitched()
 
 			sText = self.colorText(lList2[i][0], bEnabled)
-			screen.setTableText("WBGameOptions", iColumn * 2, iRow, sText, "", WidgetTypes.WIDGET_PYTHON, 1028, item, CvUtil.FONT_LEFT_JUSTIFY)
+			screen.setTableText("WBGameOptions", 2, iRow, sText, "", WidgetTypes.WIDGET_PYTHON, 1028, item, CvUtil.FONT_LEFT_JUSTIFY)
 			sText = self.colorText(CyTranslator().getText("TXT_KEY_WB_DEFAULT", ()), bDefault)
-			screen.setTableText("WBGameOptions", iColumn * 2 + 1, iRow, sText, "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_CENTER_JUSTIFY)
+			screen.setTableText("WBGameOptions", 3, iRow, sText, "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_CENTER_JUSTIFY)
+						
+		for i in xrange(len(lList3)):
+			item = lList3[i][1]
+			iRow = iNumRows + 3 + i
+
+			bEnabled = False
+			
+			if item == 3001:
+				bEnabled = sd.getAlreadySwitched()
+
+			sText = self.colorText(lList3[i][0], bEnabled)
+			screen.setTableText("WBGameOptions", 4, iRow, sText, "", WidgetTypes.WIDGET_PYTHON, 1028, item, CvUtil.FONT_LEFT_JUSTIFY)
 
 	def handleInput(self, inputClass):
 		screen = CyGInterfaceScreen("WBGameDataScreen", CvScreenEnums.WB_GAMEDATA)
@@ -404,7 +418,8 @@ class WBGameDataScreen:
 					sd.setIgnoreAI(not sd.isIgnoreAI())
 				elif iGameOption == 2003:
 					sd.setUnlimitedSwitching(not sd.getUnlimitedSwitching())
-				elif iGameOption == 2004:
+				# Stored Variables
+				elif iGameOption == 3001:
 					sd.setAlreadySwitched(not sd.getAlreadySwitched())
 			self.placeGameOptions()
 

--- a/Assets/Python/Screens/PlatyBuilder/WBGameDataScreen.py
+++ b/Assets/Python/Screens/PlatyBuilder/WBGameDataScreen.py
@@ -267,7 +267,7 @@ class WBGameDataScreen:
 
 		iRow = iNumRows + 3
 		for iCiv in con.lSecondaryCivs:
-			bEnabled = sd.getPlayerEnabled(iCiv)
+			bEnabled = sd.isPlayerEnabled(iCiv)
 			bDefault = True
 			if iCiv in [con.iHarappa, con.iPolynesia]:
 				bDefault = False
@@ -293,7 +293,7 @@ class WBGameDataScreen:
 				bEnabled = sd.isIgnoreAI()
 				bDefault = True
 			elif item == 2003:
-				bEnabled = sd.getUnlimitedSwitching()
+				bEnabled = sd.isUnlimitedSwitching()
 
 			sText = self.colorText(lList2[i][0], bEnabled)
 			screen.setTableText("WBGameOptions", 2, iRow, sText, "", WidgetTypes.WIDGET_PYTHON, 1028, item, CvUtil.FONT_LEFT_JUSTIFY)
@@ -307,7 +307,7 @@ class WBGameDataScreen:
 			bEnabled = False
 			
 			if item == 3001:
-				bEnabled = sd.getAlreadySwitched()
+				bEnabled = sd.isAlreadySwitched()
 
 			sText = self.colorText(lList3[i][0], bEnabled)
 			screen.setTableText("WBGameOptions", 4, iRow, sText, "", WidgetTypes.WIDGET_PYTHON, 1028, item, CvUtil.FONT_LEFT_JUSTIFY)
@@ -408,7 +408,7 @@ class WBGameDataScreen:
 				# Enabling/disabling secondary civs
 				if iGameOption < 2000:
 					iItem = iGameOption - 1000
-					sd.setPlayerEnabled(iItem, not sd.getPlayerEnabled(iItem))
+					sd.setPlayerEnabled(iItem, not sd.isPlayerEnabled(iItem))
 				# Enabling/disabling RFC options
 				elif iGameOption == 2000:
 					sd.setNoStability(not sd.getNoStability())
@@ -417,10 +417,10 @@ class WBGameDataScreen:
 				elif iGameOption == 2002:
 					sd.setIgnoreAI(not sd.isIgnoreAI())
 				elif iGameOption == 2003:
-					sd.setUnlimitedSwitching(not sd.getUnlimitedSwitching())
+					sd.setUnlimitedSwitching(not sd.isUnlimitedSwitching())
 				# Stored Variables
 				elif iGameOption == 3001:
-					sd.setAlreadySwitched(not sd.getAlreadySwitched())
+					sd.setAlreadySwitched(not sd.isAlreadySwitched())
 			self.placeGameOptions()
 
 		elif inputClass.getFunctionName() == "HiddenOptions":

--- a/Assets/Python/Screens/PlatyBuilder/WBPlayerScreen.py
+++ b/Assets/Python/Screens/PlatyBuilder/WBPlayerScreen.py
@@ -15,7 +15,6 @@ gc = CyGlobalContext()
 iChange = 1
 
 from StoredData import sd
-from RFCUtils import utils
 import Consts as con
 import Modifiers
 localText = CyTranslator()
@@ -169,7 +168,7 @@ class WBPlayerScreen:
 		#Merijn: Place Civenabled buttons
 		iY += 30
 		if iPlayer in con.lSecondaryCivs:
-			if utils.getPlayerEnabled(iPlayer):
+			if sd.isPlayerEnabled(iPlayer):
 				screen.setButtonGFC("CivEnabledButton", "", gc.getMissionInfo(gc.getInfoTypeForString("MISSION_FOUND")).getButton(), iX, iY, 64, 64, WidgetTypes.WIDGET_PYTHON, 22001, 0, ButtonStyles.BUTTON_STYLE_STANDARD)
 			else:
 				screen.setButtonGFC("CivEnabledButton", "", CyArtFileMgr().getInterfaceArtInfo("INTERFACE_BUTTONS_CANCEL").getPath(), iX, iY, 64, 64, WidgetTypes.WIDGET_PYTHON, 22001, 1, ButtonStyles.BUTTON_STYLE_STANDARD)
@@ -478,10 +477,7 @@ class WBPlayerScreen:
 			self.interfaceScreen(iPlayer)
 			
 		elif inputClass.getFunctionName() == "CivEnabledButton":
-			if utils.getPlayerEnabled(iPlayer):
-				sd.setPlayerEnabled(iPlayer, False)
-			else:
-				sd.setPlayerEnabled(iPlayer, True)
+			sd.setPlayerEnabled(iPlayer, not sd.isPlayerEnabled(iPlayer))
 			self.interfaceScreen(iPlayer)
 			
 		elif inputClass.getFunctionName() == "PlayerEditScriptData":

--- a/Assets/Python/Screens/PlatyBuilder/WBPlayerScreen.py
+++ b/Assets/Python/Screens/PlatyBuilder/WBPlayerScreen.py
@@ -14,6 +14,7 @@ import Popup
 gc = CyGlobalContext()
 iChange = 1
 
+from StoredData import sd
 from RFCUtils import utils
 import Consts as con
 import Modifiers
@@ -478,9 +479,9 @@ class WBPlayerScreen:
 			
 		elif inputClass.getFunctionName() == "CivEnabledButton":
 			if utils.getPlayerEnabled(iPlayer):
-				utils.setPlayerEnabled(iPlayer, False)
+				sd.setPlayerEnabled(iPlayer, False)
 			else:
-				utils.setPlayerEnabled(iPlayer, True)
+				sd.setPlayerEnabled(iPlayer, True)
 			self.interfaceScreen(iPlayer)
 			
 		elif inputClass.getFunctionName() == "PlayerEditScriptData":

--- a/Assets/Python/Stability.py
+++ b/Assets/Python/Stability.py
@@ -172,6 +172,10 @@ def isImmune(iPlayer):
 	pPlayer = gc.getPlayer(iPlayer)
 	iGameTurn = gc.getGame().getGameTurn()
 	
+	# immune if stability disabled
+	if sd.getNoStability():
+		return True
+	
 	# must not be dead
 	if not pPlayer.isAlive() or pPlayer.getNumCities() == 0:
 		return True
@@ -190,6 +194,10 @@ def isImmune(iPlayer):
 		
 	# immune right after resurrection
 	if iGameTurn - pPlayer.getLatestRebellionTurn() < utils.getTurns(10):
+		return True
+		
+	# human player immunity if option is enabled
+	if iPlayer == utils.getHumanID() and sd.getNoHumanStability():
 		return True
 		
 	return False

--- a/Assets/Python/Stability.py
+++ b/Assets/Python/Stability.py
@@ -33,6 +33,9 @@ tCrisisTypes = (
 )
 
 def checkTurn(iGameTurn):
+	if sd.getNoStability():
+		return
+	
 	for iPlayer in range(iNumPlayers):
 		if sd.getTurnsToCollapse(iPlayer) == 0:
 			sd.setTurnsToCollapse(iPlayer, -1)
@@ -89,6 +92,9 @@ def onCityAcquired(city, iOwner, iPlayer):
 		checkBarbarianCollapse(iOwner)
 		
 def onCityRazed(iPlayer, city):
+	if sd.getNoStability():
+		return
+	
 	iOwner = city.getOwner()
 	
 	if iOwner == iBarbarian: return
@@ -107,6 +113,9 @@ def onTechAcquired(iPlayer, iTech):
 	checkStability(iPlayer)
 	
 def onVassalState(iMaster, iVassal):
+	if sd.getNoStability():
+		return
+	
 	setStabilityLevel(iVassal, max(iStabilityShaky, getStabilityLevel(iVassal)))
 	checkStability(iMaster, True)
 	
@@ -114,6 +123,9 @@ def onVassalState(iMaster, iVassal):
 	sd.setNumPreviousCities(iVassal, gc.getPlayer(iVassal).getNumCities())
 	
 def onChangeWar(bWar, iTeam, iOtherTeam):
+	if sd.getNoStability():
+		return
+	
 	if iTeam < iNumPlayers and iOtherTeam < iNumPlayers:
 		checkStability(iTeam, not bWar)
 		checkStability(iOtherTeam, not bWar, bWar and utils.getHumanID() == iTeam)
@@ -141,10 +153,16 @@ def onGreatPersonBorn(iPlayer):
 	checkStability(iPlayer, True)
 	
 def onCombatResult(iWinningPlayer, iLosingPlayer, iLostPower):
+	if sd.getNoStability():
+		return
+	
 	if iWinningPlayer == iBarbarian and iLosingPlayer < iNumPlayers:
 		sd.changeBarbarianLosses(iLosingPlayer, 1)
 	
 def onCivSpawn(iPlayer):
+	if sd.getNoStability():
+		return
+	
 	for iOlderNeighbor in lOlderNeighbours[iPlayer]:
 		if gc.getPlayer(iOlderNeighbor).isAlive() and getStabilityLevel(iOlderNeighbor) > iStabilityShaky:
 			decrementStability(iOlderNeighbor)
@@ -299,6 +317,9 @@ def getStabilityThreshold(iPlayer):
 	return iThreshold
 
 def checkStability(iPlayer, bPositive = False, bWar = False, iMaster = -1):
+	if sd.getNoStability():
+		return
+	
 	pPlayer = gc.getPlayer(iPlayer)
 	iGameTurn = gc.getGame().getGameTurn()
 	iGameEra = gc.getGame().getCurrentEra()

--- a/Assets/Python/StoredData.py
+++ b/Assets/Python/StoredData.py
@@ -37,6 +37,7 @@ class StoredData:
 				    'lTempPlots': [],
 				    'iSpawnWar': 0, #if 1, add units and declare war. If >=2, do nothing
 				    'bAlreadySwitched': False,
+					'bUnlimitedSwitching': False,
 				    'lColonistsAlreadyGiven': [0 for i in range(con.iNumPlayers)], #active players
 				    'lAstronomyTurn': [1500 for i in range(con.iNumPlayers)], #active players
 				    'lNumCities': [0 for i in range(con.iNumTotalPlayers)], #total players to contain Byzantium too
@@ -136,6 +137,8 @@ class StoredData:
 				    'lWarTrend' : [[[] for i in range(con.iNumPlayers)] for j in range(con.iNumPlayers)],
 				    'lWarStartTurn' : [[0 for i in range(con.iNumPlayers)] for j in range(con.iNumPlayers)],
 				    'dSecedingCities' : {},
+					'bNoHumanStability': False,
+					'bNoAIStability': False,
 				}
 		self.save()
 		
@@ -149,6 +152,24 @@ class StoredData:
 		
 	def resetTimedConquests(self):
 		self.scriptDict['lTimedConquests'] = []
+		
+	def setPlayerEnabled(self, iCiv, bNewValue):
+		self.scriptDict['lPlayerEnabled'][con.lSecondaryCivs.index(iCiv)] = bNewValue
+		
+	def getPlayerEnabled(self, iCiv):
+		return self.scriptDict['lPlayerEnabled'][con.lSecondaryCivs.index(iCiv)]
+		
+	def getAlreadySwitched( self ):
+		return self.scriptDict['bAlreadySwitched']
+
+	def setAlreadySwitched( self, bNewValue ):
+		self.scriptDict['bAlreadySwitched'] = bNewValue
+		
+	def setUnlimitedSwitching(self, bNewValue):
+		self.scriptDict['bUnlimitedSwitching'] = bNewValue
+		
+	def getUnlimitedSwitching(self):
+		return self.scriptDict['bUnlimitedSwitching']
 		
 	# STABILITY
 		
@@ -330,6 +351,18 @@ class StoredData:
 	
 	def setSecedingCities(self, iPlayer, lCities):
 		self.scriptDict['dSecedingCities'][iPlayer] = [city.getID() for city in lCities]
+		
+	def setNoHumanStability(self, bNewValue):
+		self.scriptDict['bNoHumanStability'] = bNewValue
+		
+	def getNoHumanStability(self):
+		return self.scriptDict['bNoHumanStability']
+		
+	def setNoStability(self, bNewValue):
+		self.scriptDict['bNoAIStability'] = bNewValue
+		
+	def getNoStability(self):
+		return self.scriptDict['bNoAIStability']
 		
 	# AIWARS
 		

--- a/Assets/Python/StoredData.py
+++ b/Assets/Python/StoredData.py
@@ -156,10 +156,10 @@ class StoredData:
 	def setPlayerEnabled(self, iCiv, bNewValue):
 		self.scriptDict['lPlayerEnabled'][con.lSecondaryCivs.index(iCiv)] = bNewValue
 		
-	def getPlayerEnabled(self, iCiv):
+	def isPlayerEnabled(self, iCiv):
 		return self.scriptDict['lPlayerEnabled'][con.lSecondaryCivs.index(iCiv)]
 		
-	def getAlreadySwitched( self ):
+	def isAlreadySwitched( self ):
 		return self.scriptDict['bAlreadySwitched']
 
 	def setAlreadySwitched( self, bNewValue ):
@@ -168,7 +168,7 @@ class StoredData:
 	def setUnlimitedSwitching(self, bNewValue):
 		self.scriptDict['bUnlimitedSwitching'] = bNewValue
 		
-	def getUnlimitedSwitching(self):
+	def isUnlimitedSwitching(self):
 		return self.scriptDict['bUnlimitedSwitching']
 		
 	# STABILITY

--- a/Assets/Python/StoredData.py
+++ b/Assets/Python/StoredData.py
@@ -83,14 +83,16 @@ class StoredData:
 				    'iCongressTurns': 0,
 				    'iCivsWithNationalism': 0,
 				    'currentCongress': None,
+					'bNoCongressOption': False,
 				    #------------Plague
 				    'lPlagueCountdown': [0 for i in range(con.iNumTotalPlayersB)], #total players + barbarians
 				    'lGenericPlagueDates': [-1, -1, -1, -1],# -1],
 				    'lFirstContactPlague': [False for i in range(con.iNumTotalPlayersB)], #total players + barbarians
+					'bNoPlagueOption': False,
 				     #------------Victories
 				    'lGoals': [[-1, -1, -1] for i in range(con.iNumPlayers)],
 				    'lHistoricalGoldenAge' : [False for i in range(con.iNumPlayers)],
-				    'bIgnoreAI': False,
+				    'bIgnoreAI': True,
 				    
 				    'lWonderBuilder': [-1 for i in range(con.iNumBuildings - con.iBeginWonders)],
 				    'lReligionFounder': [-1 for i in range(con.iNumReligions)],
@@ -159,10 +161,10 @@ class StoredData:
 	def isPlayerEnabled(self, iCiv):
 		return self.scriptDict['lPlayerEnabled'][con.lSecondaryCivs.index(iCiv)]
 		
-	def isAlreadySwitched( self ):
+	def isAlreadySwitched(self):
 		return self.scriptDict['bAlreadySwitched']
 
-	def setAlreadySwitched( self, bNewValue ):
+	def setAlreadySwitched(self, bNewValue):
 		self.scriptDict['bAlreadySwitched'] = bNewValue
 		
 	def setUnlimitedSwitching(self, bNewValue):
@@ -426,6 +428,38 @@ class StoredData:
 	def setCurrentCongress(self, congress):
 		self.scriptDict['currentCongress'] = congress
 		
+	def setNoCongressOption(self, bNewValue):
+		self.scriptDict['bNoCongressOption'] = bNewValue
+		
+	def isNoCongressOption(self):
+		return self.scriptDict['bNoCongressOption']
+
+	# PLAGUE
+	
+	def getPlagueCountdown(self, iCiv):
+		return self.scriptDict['lPlagueCountdown'][iCiv]
+
+	def setPlagueCountdown(self, iCiv, iNewValue):
+		self.scriptDict['lPlagueCountdown'][iCiv] = iNewValue
+
+	def getGenericPlagueDates(self, i):
+		return self.scriptDict['lGenericPlagueDates'][i]
+
+	def setGenericPlagueDates(self, i, iNewValue):
+		self.scriptDict['lGenericPlagueDates'][i] = iNewValue
+		
+	def getFirstContactPlague(self, iCiv):
+		return self.scriptDict['lFirstContactPlague'][iCiv]
+
+	def setFirstContactPlague(self, iCiv, bNewValue):
+		self.scriptDict['lFirstContactPlague'][iCiv] = bNewValue	
+
+	def setNoPlagueOption(self, bNewValue):
+		self.scriptDict['bNoPlagueOption'] = bNewValue
+
+	def isNoPlagueOption(self):
+		return self.scriptDict['bNoPlagueOption']
+
 	# VICTORY
 	
 	def getGoal(self, iPlayer, iGoal):

--- a/Assets/XML/GlobalDefinesAlt.xml
+++ b/Assets/XML/GlobalDefinesAlt.xml
@@ -20,6 +20,19 @@
 		<DefineName>AI_SLAVE_VALUE</DefineName>
 		<iDefineIntVal>50</iDefineIntVal>
 	</Define>
+	<!-- Merijn: Additional options for game personalization -->
+	<Define>
+		<DefineName>NO_HUMAN_STABILITY</DefineName>
+		<iDefineIntVal>0</iDefineIntVal>			<!-- default: 0 -->
+	</Define>
+	<Define>
+		<DefineName>NO_STABILITY</DefineName>
+		<iDefineIntVal>0</iDefineIntVal>			<!-- default: 0 -->
+	</Define>
+	<Define>
+		<DefineName>UNLIMITED_SWITCHING</DefineName>
+		<iDefineIntVal>0</iDefineIntVal>			<!-- default: 0 -->
+	</Define>
 	<!--Leoreth: define how often these optional civs should appear
 			value=0	Civilization never appears
 			value>0	Civilization roughly appears in every i-th game, where i is the entered value

--- a/Assets/XML/GlobalDefinesAlt.xml
+++ b/Assets/XML/GlobalDefinesAlt.xml
@@ -33,6 +33,14 @@
 		<DefineName>UNLIMITED_SWITCHING</DefineName>
 		<iDefineIntVal>0</iDefineIntVal>			<!-- default: 0 -->
 	</Define>
+	<Define>
+		<DefineName>NO_CONGRESSES</DefineName>
+		<iDefineIntVal>0</iDefineIntVal>			<!-- default: 0 -->
+	</Define>
+	<Define>
+		<DefineName>NO_PLAGUES</DefineName>
+		<iDefineIntVal>0</iDefineIntVal>			<!-- default: 0 -->
+	</Define>
 	<!--Leoreth: define how often these optional civs should appear
 			value=0	Civilization never appears
 			value>0	Civilization roughly appears in every i-th game, where i is the entered value

--- a/Assets/XML/Text/External/Platy Builder.xml
+++ b/Assets/XML/Text/External/Platy Builder.xml
@@ -744,4 +744,56 @@
 		<Tag>TXT_KEY_WB_WARVALUE</Tag>
 		<English>Warvalue</English>
 	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_NO_STABILITY</Tag>
+		<English>No Stability (all civs)</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_NO_STABILITY_TEXT</Tag>
+		<English>Ignores stability checks for all civilizations. Civilizations cannot collapse.</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_NO_HUMAN_STABILITY</Tag>
+		<English>No Stability Human Player</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_NO_HUMAN_STABILITY_TEXT</Tag>
+		<English>Ignores stability checks for the human player. The human player cannot collapse. AI civilizations can still collapse.</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_IGNORE_AI_UHV</Tag>
+		<English>Ignore AI UHV Checks</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_IGNORE_AI_UHV_TEXT</Tag>
+		<English>Ignores checks for the AI unique historical victory goals. Increases speed if disabled. (The AI is not aware of the historical victory goals and will not attempt to achieve these)</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_UNLIMITED_SWITCHING</Tag>
+		<English>Unlimited Civ Switching</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_UNLIMITED_SWITCHING_TEXT</Tag>
+		<English>Allows the human player to switch multiple times.</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_ALREADY_SWITCHED</Tag>
+		<English>Already Switched Civ</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_ALREADY_SWITCHED_TEXT</Tag>
+		<English>Function to reset the "already switched" variable. (This is not really an option, but a function to change the "already switched" variable in the StoredData)</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_SECONDARY_CIVS</Tag>
+		<English>Enabled secondary civilizations</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_RFC_OPTIONS</Tag>
+		<English>RFC DoC options</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_OPTIONS_ENABLE_CIV</Tag>
+		<English>Enable/disable civ</English>
+	</TEXT>
 </Civ4GameText>

--- a/Assets/XML/Text/External/Platy Builder.xml
+++ b/Assets/XML/Text/External/Platy Builder.xml
@@ -750,15 +750,15 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_WB_NO_STABILITY_TEXT</Tag>
-		<English>Ignores stability checks for all civilizations. Civilizations cannot collapse.</English>
+		<English>Prevents stability calculations for all civilizations. No civilization can collapse.[NEWLINE](It also prevents storing of various stability parameters. When enabling stability again, all civilizations start with the parameters when the stability was disabled.)</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_WB_NO_HUMAN_STABILITY</Tag>
-		<English>No Stability Human Player</English>
+		<English>No collapsing Human Player</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_WB_NO_HUMAN_STABILITY_TEXT</Tag>
-		<English>Ignores stability checks for the human player. The human player cannot collapse. AI civilizations can still collapse.</English>
+		<English>Ignores stability checks for the human player. The human player cannot collapse. AI civilizations can still collapse. (Various calculations and parameter updates still run in the background, but cannot lead to collapse)</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_WB_IGNORE_AI_UHV</Tag>
@@ -766,7 +766,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_WB_IGNORE_AI_UHV_TEXT</Tag>
-		<English>Ignores checks for the AI unique historical victory goals. Increases speed if disabled. (The AI is not aware of the historical victory goals and will not attempt to achieve these)</English>
+		<English>Ignores checks for the AI unique historical victory goals. It increases speed if enabled.[NEWLINE](The AI is not aware of the historical victory goals and will not attempt to achieve these)</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_WB_UNLIMITED_SWITCHING</Tag>
@@ -782,7 +782,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_WB_ALREADY_SWITCHED_TEXT</Tag>
-		<English>Function to reset the "already switched" variable. (This is not really an option, but a function to change the "already switched" variable in the StoredData)</English>
+		<English>Variable which stores if the player has already switched. (Red means the player CAN still switch)</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_WB_SECONDARY_CIVS</Tag>
@@ -791,6 +791,10 @@
 	<TEXT>
 		<Tag>TXT_KEY_WB_RFC_OPTIONS</Tag>
 		<English>RFC DoC options</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_RFC_VARIABLES</Tag>
+		<English>Stored variables</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_WB_OPTIONS_ENABLE_CIV</Tag>

--- a/Assets/XML/Text/External/Platy Builder.xml
+++ b/Assets/XML/Text/External/Platy Builder.xml
@@ -749,7 +749,7 @@
 		<English>No Stability (all civs)</English>
 	</TEXT>
 	<TEXT>
-		<Tag>TXT_KEY_WB_NO_STABILITY_TEXT</Tag>
+		<Tag>TXT_KEY_WB_NO_STABILITY_HELP</Tag>
 		<English>Prevents stability calculations for all civilizations. No civilization can collapse.[NEWLINE](It also prevents storing of various stability parameters. When enabling stability again, all civilizations start with the parameters when the stability was disabled.)</English>
 	</TEXT>
 	<TEXT>
@@ -757,7 +757,7 @@
 		<English>No collapsing Human Player</English>
 	</TEXT>
 	<TEXT>
-		<Tag>TXT_KEY_WB_NO_HUMAN_STABILITY_TEXT</Tag>
+		<Tag>TXT_KEY_WB_NO_HUMAN_STABILITY_HELP</Tag>
 		<English>Ignores stability checks for the human player. The human player cannot collapse. AI civilizations can still collapse. (Various calculations and parameter updates still run in the background, but cannot lead to collapse)</English>
 	</TEXT>
 	<TEXT>
@@ -765,7 +765,7 @@
 		<English>Ignore AI UHV Checks</English>
 	</TEXT>
 	<TEXT>
-		<Tag>TXT_KEY_WB_IGNORE_AI_UHV_TEXT</Tag>
+		<Tag>TXT_KEY_WB_IGNORE_AI_UHV_HELP</Tag>
 		<English>Ignores checks for the AI unique historical victory goals. It increases speed if enabled.[NEWLINE](The AI is not aware of the historical victory goals and will not attempt to achieve these)</English>
 	</TEXT>
 	<TEXT>
@@ -773,7 +773,7 @@
 		<English>Unlimited Civ Switching</English>
 	</TEXT>
 	<TEXT>
-		<Tag>TXT_KEY_WB_UNLIMITED_SWITCHING_TEXT</Tag>
+		<Tag>TXT_KEY_WB_UNLIMITED_SWITCHING_HELP</Tag>
 		<English>Allows the human player to switch multiple times.</English>
 	</TEXT>
 	<TEXT>
@@ -781,8 +781,32 @@
 		<English>Already Switched Civ</English>
 	</TEXT>
 	<TEXT>
-		<Tag>TXT_KEY_WB_ALREADY_SWITCHED_TEXT</Tag>
+		<Tag>TXT_KEY_WB_ALREADY_SWITCHED_HELP</Tag>
 		<English>Variable which stores if the player has already switched. (Red means the player CAN still switch)</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_NO_CONGRESS</Tag>
+		<English>No congresses</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_NO_CONGRESS_HELP</Tag>
+		<English>Disables congresses. Both normal and war congresses.</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_NO_PLAGUE</Tag>
+		<English>No plagues</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_NO_PLAGUE_HELP</Tag>
+		<English>Disables the start of a plague and all effects of the plague.</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_CONGRESS_TURNS</Tag>
+		<English>Congress turns</English>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_WB_CONGRESS_TURNS_HELP</Tag>
+		<English>Number of turns left before the next congress starts. Click to reduce the amount of turns by the given amount.[NEWLINE](-1 indicates that congresses are not possible)</English>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_WB_SECONDARY_CIVS</Tag>


### PR DESCRIPTION
- Added some new options: No Human Stability, No stability all civs, unlimited switching (All off by default)
- All options can be changed during the game in the WB (gameoptions menu)
- Added function to enable/disable secondary civs in the gameoption menu
- Moved setPlayerEnabled function to StoredData.py (It was in several places. Now it is in just one place)

Several people asked how to to modify their game to incorporate these changes. These new options make it a lot easier for them.
