### PR TITLE
Changed worker build action highlights

### DIFF
--- a/CvGameCoreDLL/CvUnit.cpp
+++ b/CvGameCoreDLL/CvUnit.cpp
@@ -1864,6 +1864,21 @@ bool CvUnit::isActionRecommended(int iAction)
 				eRoute = ((RouteTypes)(GC.getBuildInfo(eBuild).getRoute()));
 				eBonus = pPlot->getBonusType(getTeam());
 				pWorkingCity = pPlot->getWorkingCity();
+				
+				if (eImprovement != NO_IMPROVEMENT)
+				{
+					if (eBonus != NO_BONUS)
+					{
+						if (GC.getImprovementInfo(eImprovement).isImprovementBonusTrade(eBonus))
+						{
+							return true;
+						}
+						else
+						{
+							return false;
+						}
+					}
+				}
 
 				if (pPlot->getImprovementType() == NO_IMPROVEMENT)
 				{


### PR DESCRIPTION
- If a tile has a resource, only the "correct" improvement is highlighted, all other improvements are not highlighted even if the old rules would
- If a tile has a resource and the "wrong" improvement, the "correct" improvement is highlighted (previously no improvement was highlighted on improved tiles)

Improved method to calculate top cities in info screen