### PR TITLE
Update CIV4UnitInfos.xml

### DIFF
--- a/Assets/XML/Buildings/CIV4BuildingInfos.xml
+++ b/Assets/XML/Buildings/CIV4BuildingInfos.xml
@@ -10893,7 +10893,7 @@
 			<ConstructSound>AS2D_BUILD_BARRACKS</ConstructSound>
 			<BuildingClassNeededs>
 				<BuildingClassNeeded>
-					<BuildingClassType>BUILDINGCLASS_SECURITY_BUREAU</BuildingClassType>
+					<BuildingClassType>BUILDINGCLASS_INTELLIGENCE_AGENCY</BuildingClassType>
 					<bNeededInCity>1</bNeededInCity>
 				</BuildingClassNeeded>
 			</BuildingClassNeededs>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -4587,8 +4587,6 @@
 			</UnitAIs>
 			<PrereqTech>TECH_SOCIAL_SERVICES</PrereqTech>
 			<TechTypes>
-				<PrereqTech>TECH_REPLACEABLE_PARTS</PrereqTech>
-			</TechTypes>
 			<iCost>140</iCost>
 			<iAdvancedStartCost>100</iAdvancedStartCost>
 			<iMinAreaSize>-1</iMinAreaSize>


### PR DESCRIPTION
* Removed Replaceable Parts as a prerequisite for Infantry, as Replaceable Parts is required to research Social Services.
* Changed Lubyanka prerequisite building to Intelligence Agency (Security Bureau now comes too late for Lubyanka to be built in time - Computers is supposed to be built after the collapse of the Soviet Union, while Lubyanka has been in use since 1918.