### PR TITLE
Platybuilder updates

### DIFF
--- a/Assets/Python/Screens/PlatyBuilder/CvPlatyBuilderScreen.py
+++ b/Assets/Python/Screens/PlatyBuilder/CvPlatyBuilderScreen.py
@@ -1876,8 +1876,6 @@ class CvWorldBuilderScreen:
 	def showFlipZone(self):
 		utils.removeStabilityOverlay()
 		if self.m_iCurrentPlayer < iNumPlayers:
-			sColor = "COLOR_MAGENTA"
-			sColorAI = "COLOR_RED"
 			if self.m_iCurrentPlayer in self.dFlipZoneEdits.keys():
 				lHumanPlotList = self.dFlipZoneEdits[self.m_iCurrentPlayer]
 			else:
@@ -1886,22 +1884,25 @@ class CvWorldBuilderScreen:
 					lHumanPlotList = Areas.getRebirthArea(self.m_iCurrentPlayer)
 				else:
 					lHumanPlotList = Areas.getBirthArea(self.m_iCurrentPlayer)
+			for tPlot in lHumanPlotList:
+				if tPlot == Areas.getCapital(self.m_iCurrentPlayer):
+					CyEngine().fillAreaBorderPlotAlt(tPlot[0], tPlot[1], 1002, "COLOR_CYAN", 0.7)
+				else:
+					CyEngine().fillAreaBorderPlotAlt(tPlot[0], tPlot[1], 1000, "COLOR_MAGENTA", 0.7)
 			# Additional cities outside flipzone (Canada)
 			lExtraCities = rnf.getConvertedCities(self.m_iCurrentPlayer)
 			for city in lExtraCities:
 				x = city.getX()
 				y = city.getY()
 				if (x, y) not in lHumanPlotList:
-					lHumanPlotList.append((x, y))
-			for tPlot in lHumanPlotList:
-				CyEngine().fillAreaBorderPlotAlt(tPlot[0], tPlot[1], 1000, sColor, 0.7)
+					 CyEngine().fillAreaBorderPlotAlt(x, y, 1003, "COLOR_PLAYER_DARK_DARK_GREEN", 0.7)
 
 			# Larger AI flipzone
 			if self.m_iCurrentPlayer in Areas.dChangedBirthArea:
 				tTL, tBR = Areas.getBirthRectangle(self.m_iCurrentPlayer, True)
 				lAIPlotList = [tPlot for tPlot in utils.getPlotList(tTL, tBR, utils.getOrElse(Areas.dBirthAreaExceptions, self.m_iCurrentPlayer, [])) if tPlot not in lHumanPlotList]
 				for tPlot in lAIPlotList:
-					CyEngine().fillAreaBorderPlotAlt(tPlot[0], tPlot[1], 1001, sColorAI, 0.7)
+					CyEngine().fillAreaBorderPlotAlt(tPlot[0], tPlot[1], 1001, "COLOR_RED", 0.7)
 
 	def showStabilityOverlay(self):
 		utils.removeStabilityOverlay()

--- a/Assets/Python/Screens/PlatyBuilder/CvPlatyBuilderScreen.py
+++ b/Assets/Python/Screens/PlatyBuilder/CvPlatyBuilderScreen.py
@@ -1462,7 +1462,10 @@ class CvWorldBuilderScreen:
 					screen.setButtonGFC("Export", CyTranslator().getText("TXT_KEY_WB_EXPORT", ()), "", iX, iY, iSpan*iAdjust-3, iButtonWidth, WidgetTypes.WIDGET_PYTHON, -1, -1, ButtonStyles.BUTTON_STYLE_STANDARD)
 					iX += iSpan*iAdjust
 					if self.iPlayerAddMode != "RegionMap":
-						bExtended = (self.m_iCurrentPlayer in Areas.dChangedCoreArea or self.m_iCurrentPlayer in Areas.dChangedNormalArea or self.m_iCurrentPlayer in Areas.dChangedBroaderArea or self.m_iCurrentPlayer in SettlerMaps.dChangedSettlerMaps or self.m_iCurrentPlayer in WarMaps.dChangedWarMaps)
+						if self.iPlayerAddMode == "Flip":
+							bExtended = (self.m_iCurrentPlayer in Areas.dRebirthArea)
+						else:
+							bExtended = (self.m_iCurrentPlayer in Areas.dChangedCoreArea or self.m_iCurrentPlayer in Areas.dChangedNormalArea or self.m_iCurrentPlayer in Areas.dChangedBroaderArea or self.m_iCurrentPlayer in SettlerMaps.dChangedSettlerMaps or self.m_iCurrentPlayer in WarMaps.dChangedWarMaps)
 						if bExtended:
 							screen.setButtonGFC("SwitchReborn", CyTranslator().getText("TXT_KEY_WB_EXTENDED", ()), "", iX, iY, 2*iAdjust-3, iButtonWidth, WidgetTypes.WIDGET_PYTHON, -1, -1, ButtonStyles.BUTTON_STYLE_STANDARD)
 						else:

--- a/Assets/Python/Screens/PlatyBuilder/CvPlatyBuilderScreen.py
+++ b/Assets/Python/Screens/PlatyBuilder/CvPlatyBuilderScreen.py
@@ -1467,9 +1467,9 @@ class CvWorldBuilderScreen:
 						else:
 							bExtended = (self.m_iCurrentPlayer in Areas.dChangedCoreArea or self.m_iCurrentPlayer in Areas.dChangedNormalArea or self.m_iCurrentPlayer in Areas.dChangedBroaderArea or self.m_iCurrentPlayer in SettlerMaps.dChangedSettlerMaps or self.m_iCurrentPlayer in WarMaps.dChangedWarMaps)
 						if bExtended:
-							screen.setButtonGFC("SwitchReborn", CyTranslator().getText("TXT_KEY_WB_EXTENDED", ()), "", iX, iY, 2*iAdjust-3, iButtonWidth, WidgetTypes.WIDGET_PYTHON, -1, -1, ButtonStyles.BUTTON_STYLE_STANDARD)
+							screen.setButtonGFC("SwitchReborn", CyTranslator().getText("TXT_KEY_WB_EXTENDED", ()), "", iX, iY, 2*iAdjust-3, iButtonWidth, WidgetTypes.WIDGET_PYTHON, 0, -1, ButtonStyles.BUTTON_STYLE_STANDARD)
 						else:
-							screen.setButtonGFC("SwitchReborn", CyTranslator().getText("TXT_KEY_WB_NA", ()), "", iX, iY, 2*iAdjust-3, iButtonWidth, WidgetTypes.WIDGET_PYTHON, -1, -1, ButtonStyles.BUTTON_STYLE_STANDARD)
+							screen.setButtonGFC("SwitchReborn", CyTranslator().getText("TXT_KEY_WB_NA", ()), "", iX, iY, 2*iAdjust-3, iButtonWidth, WidgetTypes.WIDGET_PYTHON, 1, -1, ButtonStyles.BUTTON_STYLE_STANDARD)
 
 			elif self.iPlayerAddMode in ["MoveMap", "MoveMap2"]:
 				if self.iPlayerAddMode == "MoveMap":
@@ -2534,13 +2534,15 @@ class CvWorldBuilderScreen:
 				self.showRegionOverlay()
 
 		elif inputClass.getFunctionName() == "SwitchReborn":
-			utils.setReborn(self.m_iCurrentPlayer, not utils.isReborn(self.m_iCurrentPlayer))
-			if self.iPlayerAddMode == "Flip":
-				self.showFlipZone()
-			elif self.iPlayerAddMode == "WarMap":
-				self.showWarOverlay()
-			else:
-				self.showStabilityOverlay()
+			if inputClass.getData1() == 0:
+				utils.setReborn(self.m_iCurrentPlayer, not utils.isReborn(self.m_iCurrentPlayer))
+				if self.iPlayerAddMode == "Flip":
+					self.showFlipZone()
+				elif self.iPlayerAddMode == "WarMap":
+					self.showWarOverlay()
+				else:
+					self.showStabilityOverlay()
+				dc.checkName(self.m_iCurrentPlayer)
 
 		elif inputClass.getFunctionName() == "PresetValue":
 			if self.iPlayerAddMode == "ReligionMap":

--- a/Assets/Python/Screens/PlatyBuilder/WBStoredDataScreen.py
+++ b/Assets/Python/Screens/PlatyBuilder/WBStoredDataScreen.py
@@ -173,7 +173,7 @@ class WBStoredDataScreen:
 		global iSelectedCiv
 		global iWarList
 
-		bCiv = lLists[iSelectedList] in ["lFirstDiscovered", "lWonderBuilder", "lReligionFounder", "lFirstEntered"]
+		bCiv = lLists[iSelectedList] in ["lFirstDiscovered", "lWonderBuilder", "lReligionFounder", "lFirstEntered", "lFirstGreatPeople"]
 
 		iWidth = (screen.getXResolution() * 3 / 4 - 40) / 2 - 40
 		iHeightMax = self.allignTable((screen.getYResolution() - 85 - 50 - 50) / 2)
@@ -239,6 +239,9 @@ class WBStoredDataScreen:
 			elif item == "lFirstEntered": # Eras
 				sText = gc.getEraInfo(i).getDescription()
 				screen.setTableText("WBListTableTwo", 0, i, sText, "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY)
+			elif item == "lFirstGreatPeople": # Great People
+				sText = gc.getUnitInfo(lGreatPeopleUnits[i]).getDescription()
+				screen.setTableText("WBListTableTwo", 0, i, sText, gc.getUnitInfo(lGreatPeopleUnits[i]).getButton(), WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY)
 			elif item == "lStabilityCategoryValues": # Stability Categories
 				sText = CyTranslator().getText(StabilityTypesTexts[i], ())
 				screen.setTableText("WBListTableTwo", 0, i, sText, "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY)
@@ -394,7 +397,7 @@ class WBStoredDataScreen:
 				else:
 					data.players[iSelectedCiv].__dict__[sList][iItem] = not data.players[iSelectedCiv].__dict__[sList][iItem]
 			elif isinstance(scriptDict[sList][iItem], int):
-				bCiv = sList in ["lFirstDiscovered", "lWonderBuilder", "lReligionFounder", "lFirstEntered"]
+				bCiv = sList in ["lFirstDiscovered", "lWonderBuilder", "lReligionFounder", "lFirstEntered", "lFirstGreatPeople"]
 				if bCiv:
 					data.__dict__[sList][iItem] = iSelectedCiv
 				else:

--- a/Assets/Python/Screens/PlatyBuilder/WBStoredDataScreen.py
+++ b/Assets/Python/Screens/PlatyBuilder/WBStoredDataScreen.py
@@ -163,6 +163,8 @@ class WBStoredDataScreen:
 					sText += u" (%s)" % CyTranslator().getText(StabilityLevelTexts[scriptDict[item]], ())
 				elif item in ["iAstronomyTurn", "iNextTurnAIWar"]:
 					sText += u" (Turn %s)" % getTurnForYear(scriptDict[item])
+				elif item == "iFirstNewWorldColony":
+					sText = self.getCivName(scriptDict[item])
 				screen.setTableText("WBDataTable", 2*iColumn+3, iRow, sText, "", WidgetTypes.WIDGET_PYTHON, 22008, i, CvUtil.FONT_LEFT_JUSTIFY)
 
 	def placeListTables(self):
@@ -261,11 +263,10 @@ class WBStoredDataScreen:
 				screen.setTableText("WBListTableTwo", 0, i, str(i), "", WidgetTypes.WIDGET_PYTHON, -1, i, CvUtil.FONT_LEFT_JUSTIFY)
 
 			if bCiv:
+				sText = self.getCivName(lSelectedList[i])
 				if lSelectedList[i] == -1:
-					sText = CyTranslator().getText("TXT_KEY_CULTURELEVEL_NONE", ())
 					screen.setTableText("WBListTableTwo", 1, i, sText, CyArtFileMgr().getInterfaceArtInfo("INTERFACE_BUTTONS_CANCEL").getPath(), WidgetTypes.WIDGET_PYTHON, 22008, i, CvUtil.FONT_LEFT_JUSTIFY)
 				else:
-					sText = CyTranslator().getText(str(gc.getPlayer(lSelectedList[i]).getCivilizationShortDescriptionKey()), ())
 					screen.setTableText("WBListTableTwo", 1, i, sText, gc.getCivilizationInfo(gc.getPlayer(lSelectedList[i]).getCivilizationType()).getButton(), WidgetTypes.WIDGET_PYTHON, 22008, i, CvUtil.FONT_LEFT_JUSTIFY)
 			else:
 				sText = str(lSelectedList[i])
@@ -303,6 +304,11 @@ class WBStoredDataScreen:
 		else:
 			data.players[iSelectedCiv].__dict__[lLists[iSelectedList]][iItem] = iValue
 		self.placeListTables()
+
+	def getCivName(self, iCiv):
+		if iCiv < 0:
+			return CyTranslator().getText("TXT_KEY_CULTURELEVEL_NONE", ())
+		return CyTranslator().getText(str(gc.getPlayer(iCiv).getCivilizationShortDescriptionKey()), ())
 
 	def handleInput(self, inputClass):
 		screen = CyGInterfaceScreen("WBStoredDataScreen", CvScreenEnums.WB_STOREDDATA)
@@ -368,6 +374,8 @@ class WBStoredDataScreen:
 
 				if item == "iStabilityLevel":
 					iValue = max(iStabilityCollapsing, min(iValue, iStabilitySolid))
+				elif item == "iFirstNewWorldColony":
+					iValue = iSelectedCiv
 
 				if iSelectedMode == 0:
 					data.__dict__[item] = iValue


### PR DESCRIPTION
Updated lFirstGreatPeople in StoredData editor so it shows names and buttons

iFirstWorldColonist show civ name instead of number
Changing iFirstWorldColonist uses the selected civ instead of increasing/decreasing the value like other integers

Flipzone reborn button only works for Maya, Persia and Aztec (for Colombia, Iran and Mexico)

Flipzone editor highlights spawn plot in cyan
Flipzone editor highlights extra plots in dark green

Switching between reborn in the map editors trigger dc name check