### PR TITLE
Small fixes

### DIFF
--- a/Assets/Python/Stability.py
+++ b/Assets/Python/Stability.py
@@ -774,8 +774,9 @@ def calculateStability(iPlayer):
 	iPopulationImprovements = 0
 	for (x, y) in Areas.getCoreArea(iPlayer):
 		plot = gc.getMap().plot(x, y)
-		if plot.getImprovementType() in [iVillage, iTown]:
-			iPopulationImprovements += 1
+		if plot.getOwner() == iPlayer:
+			if plot.getImprovementType() in [iVillage, iTown]:
+				iPopulationImprovements += 1
 			
 	iCorePopulation += iCorePopulationModifier * iPopulationImprovements / 100
 	
@@ -1443,12 +1444,12 @@ def checkResurrection(iGameTurn):
 	
 		for city in utils.getAreaCities(Areas.getRespawnArea(iLoopCiv)):
 			if city.getOwner() not in [iIndependent, iIndependent2, iNative, iBarbarian]:
-				continue
-		
-		lCityList = getResurrectionCities(iLoopCiv)
-		if lCityList:
-			doResurrection(iLoopCiv, lCityList)
-			return
+				break
+		else:
+			lCityList = getResurrectionCities(iLoopCiv)
+			if lCityList:
+				doResurrection(iLoopCiv, lCityList)
+				return
 				
 	for iLoopCiv in utils.getSortedList(lPossibleResurrections, lambda x: data.players[x].iLastTurnAlive):
 		iMinNumCities = 2


### PR DESCRIPTION
Only Towns and Villages on owned tiles count for core population
Fixed Higher respawn chance for civs whose core is controlled by minors