### PR TITLE
Code refactoring

### DIFF
--- a/Assets/Python/EntryPoints/CvScreensInterface.py
+++ b/Assets/Python/EntryPoints/CvScreensInterface.py
@@ -1064,20 +1064,16 @@ def getUHVTileInfo(argsList):
 		if (x,y) in vic.lBlackSea:
 			return 48
 			
-		cx, cy = vic.tCairo
-		if cx-1 <= x <= cx+1 and cy-1 <= y <= cy+1:
+		if (x, y) in utils.surroundingPlots(vic.tCairo):
 			return 49
 				
-		cx, cy = vic.tMecca
-		if cx-1 <= x <= cx+1 and cy-1 <= y <= cy+1:
+		if (x, y) in utils.surroundingPlots(vic.tMecca):
 			return 50
 				
-		cx, cy = vic.tBaghdad
-		if cx-1 <= x <= cx+1 and cy-1 <= y <= cy+1:
+		if (x, y) in utils.surroundingPlots(vic.tBaghdad):
 			return 51
 				
-		cx, cy = tVienna
-		if cx-1 <= x <= cx+1 and cy-1 <= y <= cy+1:
+		if (x, y) in utils.surroundingPlots(vic.tVienna):
 			return 52
 			
 	elif iPlayer == iThailand:

--- a/Assets/Python/Plague.py
+++ b/Assets/Python/Plague.py
@@ -291,9 +291,8 @@ class Plague:
 							iPreserveDefenders += 1
 							break
 		if iNumUnitsInAPlot > 0:
-			for iUnit in range(iNumUnitsInAPlot):
-				i = iNumUnitsInAPlot - iUnit - 1
-				unit = pPlot.getUnit(i)
+			for iUnit in reversed(range(iNumUnitsInAPlot)):
+				unit = pPlot.getUnit(iUnit)
 				if gc.getPlayer(unit.getOwner()).isHuman():
 					#print ("iPreserveHumanDefenders", iPreserveHumanDefenders)
 					if iPreserveHumanDefenders > 0:

--- a/Assets/Python/RFCUtils.py
+++ b/Assets/Python/RFCUtils.py
@@ -113,6 +113,7 @@ class RFCUtils:
 						teamMinor.makePeace(iActiveCiv)
 						if bOpenBorders:
 							teamMinor.signOpenBorders(iActiveCiv)
+	
 	#AIWars
 	def restorePeaceHuman(self, iMinorCiv, bOpenBorders): 
 		teamMinor = gc.getTeam(gc.getPlayer(iMinorCiv).getTeam())
@@ -123,6 +124,7 @@ class RFCUtils:
 				bIndependentUnitsInActiveTerritory = self.checkUnitsInEnemyTerritory(iMinorCiv, iHuman)
 				if not bActiveUnitsInIndependentTerritory and not bIndependentUnitsInActiveTerritory:
 					teamMinor.makePeace(iHuman)
+	
 	#AIWars
 	def minorWars(self, iMinorCiv):
 		teamMinor = gc.getTeam(gc.getPlayer(iMinorCiv).getTeam())
@@ -201,32 +203,27 @@ class RFCUtils:
 	def flipUnitsInCityBefore(self, tCityPlot, iNewOwner, iOldOwner):
 		#print ("tCityPlot Before", tCityPlot)
 		plotCity = gc.getMap().plot(tCityPlot[0], tCityPlot[1])
-		city = plotCity.getPlotCity()
 		iNumUnitsInAPlot = plotCity.getNumUnits()
-		j = 0
-		for i in range(iNumUnitsInAPlot):
-			unit = plotCity.getUnit(j)
-			unitType = unit.getUnitType()
-			if unit.getOwner() == iOldOwner:
-				unit.kill(False, iBarbarian)
-				if iNewOwner < iNumActivePlayers or unitType > iSettler:
-					self.makeUnit(unitType, iNewOwner, (0, 67), 1)
-			else:
-				j += 1
+		if iNumUnitsInAPlot > 0:
+			lFlipUnits = []
+			for iUnit in reversed(range(iNumUnitsInAPlot)):
+				unit = plotCity.getUnit(iUnit)
+				iUnitType = unit.getUnitType()
+				if unit.getOwner() == iOldOwner:
+					unit.kill(False, iBarbarian)
+					if iNewOwner < iNumActivePlayers or iUnitType > iSettler:
+						lFlipUnits.append(iUnitType)
+			data.lFlippingUnits = lFlipUnits
+
 	#RiseAndFall
 	def flipUnitsInCityAfter(self, tCityPlot, iCiv):
 		#moves new units back in their place
 		print ("tCityPlot After", tCityPlot)
-		tempPlot = gc.getMap().plot(0,67)
-		if tempPlot.isUnit():
-			iNumUnitsInAPlot = tempPlot.getNumUnits()
-			#print ("iNumUnitsInAPlot", iNumUnitsInAPlot)
-			for i in range(iNumUnitsInAPlot):
-				unit = tempPlot.getUnit(0)
-				unit.setXYOld(tCityPlot[0],tCityPlot[1])
-		#cover plots revealed
-		for (x, y) in self.surroundingPlots((0, 67), 2):
-			gc.getMap().plot(x, y).setRevealed(iCiv, False, True, -1)
+		lFlipUnits = data.lFlippingUnits
+		if lFlipUnits:
+			for iUnitType in lFlipUnits:
+				self.makeUnit(iUnitType, iCiv, tCityPlot, 1)
+			data.lFlippingUnits = []
 
 	def killUnitsInArea(self, iPlayer, lPlots):
 		for (x, y) in lPlots:
@@ -243,61 +240,43 @@ class RFCUtils:
 
 	#RiseAndFall
 	def flipUnitsInArea(self, lPlots, iNewOwner, iOldOwner, bSkipPlotCity, bKillSettlers):
-		"""Deletes, recreates units in 0,67 and moves them to the previous tile.
-		If there are units belonging to others in that plot and the new owner is barbarian, the units aren't recreated.
-		Settlers aren't created.
+		"""Creates a list of all flipping units, deletes old ones and places new ones
 		If bSkipPlotCity is True, units in a city won't flip. This is to avoid converting barbarian units that would capture a city before the flip delay"""
+		oldCapital = gc.getPlayer(iOldOwner).getCapitalCity()
+		
 		for (x, y) in lPlots:
-			killPlot = gc.getMap().plot(x,y)
+			killPlot = gc.getMap().plot(x, y)
+			if bSkipPlotCity and killPlot.isCity():
+				#print (killPlot.isCity())
+				#print 'do nothing'
+				continue
+			lPlotUnits = []
 			iNumUnitsInAPlot = killPlot.getNumUnits()
 			if iNumUnitsInAPlot > 0:
-				bRevealedZero = False
-				if gc.getMap().plot(0, 67).isRevealed(iNewOwner, False):
-					bRevealedZero = True
 				#print ("killplot", x, y)
-				if bSkipPlotCity and killPlot.isCity():
-					#print (killPlot.isCity())
-					#print 'do nothing'
-					pass
-				else:
-					j = 0
-					oldCapital = gc.getPlayer(iOldOwner).getCapitalCity()
-					for i in range(iNumUnitsInAPlot):
-						unit = killPlot.getUnit(j)
-						#print ("killplot", x, y, unit.getUnitType(), unit.getOwner(), "j", j)
-						if unit.getOwner() == iOldOwner:
-							# Leoreth: Italy shouldn't flip so it doesn't get too strong by absorbing French or German armies attacking Rome
-							if iNewOwner == iItaly and iOldOwner < iNumPlayers:
-								unit.setXYOld(oldCapital.getX(), oldCapital.getY())
-							else:
-								unit.kill(False, iBarbarian)
-								
-								# Leoreth: can't flip naval units anymore
-								if unit.getDomainType() == DomainTypes.DOMAIN_SEA:
-									continue
-									
-								# Leoreth: ignore workers as well
-								if unit.getUnitType() in [iWorker, iPunjabiWorker, iMadeireiro]:
-									continue
-								
-								if not (unit.isFound() and not bKillSettlers) and not unit.isAnimal():
-									self.makeUnit(unit.getUnitType(), iNewOwner, (0, 67), 1)
+				for iUnit in reversed(range(iNumUnitsInAPlot)):
+					unit = killPlot.getUnit(iUnit)
+					#print ("killplot", x, y, unit.getUnitType(), unit.getOwner(), "j", j)
+					if unit.getOwner() == iOldOwner:
+						# Leoreth: Italy shouldn't flip so it doesn't get too strong by absorbing French or German armies attacking Rome
+						if iNewOwner == iItaly and iOldOwner < iNumPlayers:
+							unit.setXYOld(oldCapital.getX(), oldCapital.getY())
 						else:
-							j += 1
-					tempPlot = gc.getMap().plot(0,67)
-					#moves new units back in their place
-					if tempPlot.isUnit():
-						iNumUnitsInAPlot = tempPlot.getNumUnits()
-						for i in range(iNumUnitsInAPlot):
-							unit = tempPlot.getUnit(0)
-							unit.setXYOld(x,y)
-						iCiv = iNewOwner
-						if not bRevealedZero:
-							for (x, y) in self.surroundingPlots((0, 67), 2):
-								gc.getMap().plot(x, y).setRevealed(iCiv, False, True, -1)
-
-
-
+							unit.kill(False, iBarbarian)
+							
+							# Leoreth: can't flip naval units anymore
+							if unit.getDomainType() == DomainTypes.DOMAIN_SEA:
+								continue
+								
+							# Leoreth: ignore workers as well
+							if utils.getBaseUnit(unit.getUnitType()) in [iWorker, iLabourer]:
+								continue
+							
+							if not (unit.isFound() and not bKillSettlers) and not unit.isAnimal():
+								lPlotUnits.append(unit.getUnitType())
+			if lPlotUnits:
+				for iUnit in lPlotUnits:
+					self.makeUnit(iUnit, iNewOwner, (x, y), 1)
 
 	#Congresses, RiseAndFall
 	def flipCity(self, tCityPlot, bFlipType, bKillUnits, iNewOwner, iOldOwners):
@@ -467,13 +446,10 @@ class RFCUtils:
 		if tDestination != (-1, -1):
 			plotCity = gc.getMap().plot(x, y)
 			iNumUnitsInAPlot = plotCity.getNumUnits()
-			j = 0
-			for i in range(iNumUnitsInAPlot):
-				unit = plotCity.getUnit(j)
+			for iUnit in reversed(range(iNumUnitsInAPlot)):
+				unit = plotCity.getUnit(iUnit)
 				if unit.getDomainType() == DomainTypes.DOMAIN_LAND:
 					unit.setXYOld(tDestination[0], tDestination[1])
-				else:
-					j += 1
 
 	def relocateGarrisons(self, tCityPlot, iOldOwner):
 		x, y = tCityPlot
@@ -482,13 +458,10 @@ class RFCUtils:
 			if pCity:
 				plot = gc.getMap().plot(x, y)
 				iNumUnits = plot.getNumUnits()
-				j = 0
-				for i in range(iNumUnits):
-					unit = plot.getUnit(j)
+				for iUnit in reversed(range(iNumUnits)):
+					unit = plot.getUnit(iUnit)
 					if unit.getDomainType() == DomainTypes.DOMAIN_LAND:
 						unit.setXYOld(pCity.getX(), pCity.getY())
-					else:
-						j += 1
 		else:
 			plot = gc.getMap().plot(x, y)
 			iNumUnits = plot.getNumUnits()
@@ -507,16 +480,13 @@ class RFCUtils:
 					self.createGarrisons((x, y), pCity.getOwner(), 2)
 			else:
 				iNumUnits = plot.getNumUnits()
-				j = 0
-				for i in range(iNumUnits):
-					unit = plot.getUnit(j)
+				for iUnit in reversed(range(iNumUnits)):
+					unit = plot.getUnit(iUnit)
 					iOwner = unit.getOwner()
 					if iOwner < iNumPlayers and iOwner != iPlayer:
 						capital = gc.getPlayer(iOwner).getCapitalCity()
 						if capital.getX() != -1 and capital.getY() != -1:
 							unit.setXYOld(capital.getX(), capital.getY())
-					else:
-						j += 1
 				
 	#Congresses, RiseAndFall
 	def relocateSeaGarrisons(self, tCityPlot, iOldOwner):
@@ -528,13 +498,10 @@ class RFCUtils:
 		if tDestination != (-1, -1):
 			plotCity = gc.getMap().plot(x, y)
 			iNumUnitsInAPlot = plotCity.getNumUnits()
-			j = 0
-			for i in range(iNumUnitsInAPlot):
-				unit = plotCity.getUnit(j)
+			for iUnit in reversed(range(iNumUnitsInAPlot)):
+				unit = plotCity.getUnit(iUnit)
 				if unit.getOwner() == iOldOwner and unit.getDomainType() == DomainTypes.DOMAIN_SEA:
 					unit.setXYOld(tDestination[0], tDestination[1])
-				else:
-					j += 1
 
 
 	#Congresses, RiseAndFall
@@ -1264,25 +1231,25 @@ class RFCUtils:
 		return [city for city in self.getAreaCities(lPlots) if city.getOwner() == iCiv]
 		
 	def completeCityFlip(self, x, y, iCiv, iOwner, iCultureChange, bBarbarianDecay = True, bBarbarianConversion = False, bAlwaysOwnPlots = False, bFlipUnits = False):
-	
+		tPlot = (x, y)
 		plot = gc.getMap().plot(x, y)
+		
 		plot.setRevealed(iCiv, False, True, -1)
 	
 		self.cultureManager((x, y), iCultureChange, iCiv, iOwner, bBarbarianDecay, bBarbarianConversion, bAlwaysOwnPlots)
 		
 		if bFlipUnits: 
-			self.flipUnitsInCityBefore((x, y), iCiv, iOwner)
+			self.flipUnitsInCityBefore(tPlot, iCiv, iOwner)
 		else:
-			self.pushOutGarrisons((x, y), iOwner)
-			self.relocateSeaGarrisons((x, y), iOwner)
+			self.pushOutGarrisons(tPlot, iOwner)
+			self.relocateSeaGarrisons(tPlot, iOwner)
 		
-		data.tTempFlippingCity = (x, y)
-		self.flipCity((x, y), 0, 0, iCiv, [iOwner])
+		self.flipCity(tPlot, 0, 0, iCiv, [iOwner])
 		
 		if bFlipUnits: 
-			self.flipUnitsInCityAfter(data.tTempFlippingCity, iCiv)
+			self.flipUnitsInCityAfter(tPlot, iCiv)
 		else:
-			self.createGarrisons(data.tTempFlippingCity, iCiv, 2)
+			self.createGarrisons(tPlot, iCiv, 2)
 		
 		plot.setRevealed(iCiv, True, True, -1)
 	

--- a/Assets/Python/RiseAndFall.py
+++ b/Assets/Python/RiseAndFall.py
@@ -119,22 +119,20 @@ class RiseAndFall:
 		
 		iNumCities = gc.getPlayer(iNewCivFlip).getNumCities()
 
-		humanCityList = [city for city in self.getConvertedCities(iNewCivFlip, lPlots) if city.getOwner() == iHuman]
+		lHumanCityList = [city for city in self.getConvertedCities(iNewCivFlip, lPlots) if city.getOwner() == iHuman]
 		
 		if popupReturn.getButtonClicked() == 0: # 1st button
 			print ("Flip agreed")
 			CyInterface().addMessage(iHuman, True, iDuration, CyTranslator().getText("TXT_KEY_FLIP_AGREED", ()), "", 0, "", ColorTypes(iGreen), -1, -1, True, True)
 						
-			if humanCityList:
-				for i in range(len(humanCityList)):
-					city = humanCityList[i]
+			if lHumanCityList:
+				for city in lHumanCityList:
 					tCity = (city.getX(), city.getY())
 					print ("flipping ", city.getName())
 					utils.cultureManager(tCity, 100, iNewCivFlip, iHuman, False, False, False)
 					utils.flipUnitsInCityBefore(tCity, iNewCivFlip, iHuman)
-					data.tTempFlippingCity = tCity
-					utils.flipCity(tCity, 0, 0, iNewCivFlip, [iHuman])					
-					utils.flipUnitsInCityAfter(data.tTempFlippingCity, iNewCivFlip)
+					utils.flipCity(tCity, 0, 0, iNewCivFlip, [iHuman])
+					utils.flipUnitsInCityAfter(tCity, iNewCivFlip)
 					
 			if iNumCities == 0 and gc.getPlayer(iNewCivFlip).getNumCities() > 0:
 				self.createStartingWorkers(iNewCivFlip, (gc.getPlayer(iNewCivFlip).getCapitalCity().getX(), gc.getPlayer(iNewCivFlip).getCapitalCity().getY()))
@@ -145,8 +143,8 @@ class RiseAndFall:
 				if betrayalPlot.isCore(betrayalPlot.getOwner()) and not betrayalPlot.isCore(iNewCivFlip): continue
 				iNumUnitsInAPlot = betrayalPlot.getNumUnits()
 				if iNumUnitsInAPlot > 0:
-					for i in range(iNumUnitsInAPlot):
-						unit = betrayalPlot.getUnit(i)
+					for iUnit in reversed(range(iNumUnitsInAPlot)):
+						unit = betrayalPlot.getUnit(iUnit)
 						if unit.getOwner() == iHuman:
 							rndNum = gc.getGame().getSorenRandNum(100, 'betrayal')
 							if rndNum >= iBetrayalThreshold:
@@ -154,7 +152,6 @@ class RiseAndFall:
 									iUnitType = unit.getUnitType()
 									unit.kill(False, iNewCivFlip)
 									utils.makeUnit(iUnitType, iNewCivFlip, (x,y), 1)
-									i = i - 1
 
 
 			if data.lCheatersCheck[0] == 0:
@@ -166,9 +163,8 @@ class RiseAndFall:
 			CyInterface().addMessage(iHuman, True, iDuration, CyTranslator().getText("TXT_KEY_FLIP_REFUSED", ()), "", 0, "", ColorTypes(iGreen), -1, -1, True, True)
 						
 
-			if humanCityList:
-				for i in range(len(humanCityList)):
-					city = humanCityList[i]
+			if lHumanCityList:
+				for city in lHumanCityList:
 					pPlot = gc.getMap().plot(city.getX(), city.getY())
 					oldCulture = pPlot.getCulture(iHuman)
 					pPlot.setCulture(iNewCivFlip, oldCulture/2, True)
@@ -263,7 +259,7 @@ class RiseAndFall:
 		
 		Civilizations.initScenarioTechs(utils.getScenario())
 	
-		if utils.getScenario() == i3000BC:		
+		if utils.getScenario() == i3000BC:
 			self.create4000BCstartingUnits()
 			
 		if utils.getScenario() == i600AD:
@@ -519,7 +515,7 @@ class RiseAndFall:
 			pShenyang.setHasRealBuilding(iWalls, True)
 			pShenyang.setHasRealBuilding(iConfucianTemple, True)
 			
-	def adjust600ADWonders(self):	
+	def adjust600ADWonders(self):
 		pBeijing = gc.getMap().plot(102, 47).getPlotCity()
 		pBeijing.setBuildingOriginalOwner(iTaoistShrine, iChina)
 		pBeijing.setBuildingOriginalOwner(iGreatWall, iChina)
@@ -612,12 +608,11 @@ class RiseAndFall:
 			if tBirth[iCiv] > -3000 and not gc.getPlayer(iCiv).isHuman():
 				data.players[iCiv].iBirthTurnModifier = gc.getGame().getSorenRandNum(11, "BirthTurnModifier") - 5 # -5 to +5
 		#now make sure that no civs spawn in the same turn and cause a double "new civ" popup
-		for iCiv in range(iNumPlayers):
-			if iCiv > utils.getHumanID() and iCiv < iNumPlayers-1:
-				for j in range(iNumPlayers-1-iCiv):
-					iNextCiv = iCiv+j+1
-					if getTurnForYear(tBirth[iCiv]) + data.players[iCiv].iBirthTurnModifier == getTurnForYear(tBirth[iNextCiv]) + data.players[iNextCiv].iBirthTurnModifier:
-						data.players[iNextCiv].iBirthTurnModifier += 1
+		for iCiv in range(utils.getHumanID()+1, iNumPlayers):
+			for j in range(iNumPlayers-1-iCiv):
+				iNextCiv = iCiv+j+1
+				if getTurnForYear(tBirth[iCiv]) + data.players[iCiv].iBirthTurnModifier == getTurnForYear(tBirth[iNextCiv]) + data.players[iNextCiv].iBirthTurnModifier:
+					data.players[iNextCiv].iBirthTurnModifier += 1
 						
 	def placeGoodyHuts(self):
 			
@@ -898,7 +893,7 @@ class RiseAndFall:
 			iFirstSpawn = iAmerica
 			
 		for iLoopCiv in range(iFirstSpawn, iNumMajorPlayers):
-			if (iGameTurn >= getTurnForYear(tBirth[iLoopCiv]) - 2 and iGameTurn <= getTurnForYear(tBirth[iLoopCiv]) + 6):
+			if iGameTurn >= getTurnForYear(tBirth[iLoopCiv]) - 2 and iGameTurn <= getTurnForYear(tBirth[iLoopCiv]) + 6:
 				self.initBirth(iGameTurn, tBirth[iLoopCiv], iLoopCiv)
 
 
@@ -1149,10 +1144,9 @@ class RiseAndFall:
 					if iDivideCounter % 2 == 1:
 						tPlot = (city.getX(), city.getY())
 						utils.cultureManager(tPlot, 50, iSmallIndependent, iBigIndependent, False, True, True)
-						utils.flipUnitsInCityBefore(tPlot, iSmallIndependent, iBigIndependent)			    
-						data.tTempFlippingCity = tPlot
+						utils.flipUnitsInCityBefore(tPlot, iSmallIndependent, iBigIndependent)
 						utils.flipCity(tPlot, 0, 0, iSmallIndependent, [iBigIndependent])   #by trade because by conquest may raze the city
-						utils.flipUnitsInCityAfter(data.tTempFlippingCity, iSmallIndependent)
+						utils.flipUnitsInCityAfter(tPlot, iSmallIndependent)
 						iCounter += 1
 						if iCounter == 3:
 							return
@@ -1186,12 +1180,12 @@ class RiseAndFall:
 								if iDivideCounter % 4 == 0 or iDivideCounter % 4 == 1:
 									tPlot = (city.getX(), city.getY())
 									utils.cultureManager(tPlot, 50, iNewCiv, iBarbarian, False, True, True)
-									utils.flipUnitsInCityBefore(tPlot, iNewCiv, iBarbarian)			    
+									utils.flipUnitsInCityBefore(tPlot, iNewCiv, iBarbarian)
 									utils.flipCity(tPlot, 0, 0, iNewCiv, [iBarbarian])   #by trade because by conquest may raze the city
-									utils.flipUnitsInCityAfter(data.tTempFlippingCity, iNewCiv)
+									utils.flipUnitsInCityAfter(tPlot, iNewCiv)
 									iDivideCounter += 1
 					return
-		
+
 
 	def secession(self, iGameTurn):
 		iRndnum = gc.getGame().getSorenRandNum(iNumPlayers, 'starting count')
@@ -1241,17 +1235,16 @@ class RiseAndFall:
 						tPlot = (splittingCity.getX(), splittingCity.getY())
 						utils.cultureManager(tPlot, 50, iNewCiv, iPlayer, False, True, True)
 						utils.flipUnitsInCityBefore(tPlot, iNewCiv, iPlayer)
-						data.tTempFlippingCity = tPlot
 						utils.flipCity(tPlot, 0, 0, iNewCiv, [iPlayer])   #by trade because by conquest may raze the city
-						utils.flipUnitsInCityAfter(data.tTempFlippingCity, iNewCiv)
+						utils.flipUnitsInCityAfter(tPlot, iNewCiv)
 						if iPlayer == utils.getHumanID():
 							CyInterface().addMessage(iPlayer, True, iDuration, splittingCity.getName() + " " + \
 												CyTranslator().getText("TXT_KEY_STABILITY_SECESSION", ()), "", 0, "", ColorTypes(iOrange), -1, -1, True, True)
 						
 					return
-					
-			    
-				    
+
+
+
 	def initBirth(self, iCurrentTurn, iBirthYear, iCiv): # iBirthYear is really year now, so no conversion prior to function call - edead
 		print 'init birth in: '+str(iBirthYear)
 		iHuman = utils.getHumanID()
@@ -2335,8 +2328,8 @@ class RiseAndFall:
 			if killPlot.isCore(iOldOwner) and not killPlot.isCore(iNewOwner): continue
 			iNumUnitsInAPlot = killPlot.getNumUnits()
 			if iNumUnitsInAPlot > 0:
-				for i in range(iNumUnitsInAPlot):
-					unit = killPlot.getUnit(i)
+				for iUnit in reversed(range(iNumUnitsInAPlot)):
+					unit = killPlot.getUnit(iUnit)
 					if unit.getOwner() == iOldOwner:
 						rndNum = gc.getGame().getSorenRandNum(100, 'betrayal')
 						if rndNum >= iBetrayalThreshold:
@@ -2344,7 +2337,6 @@ class RiseAndFall:
 								iUnitType = unit.getUnitType()
 								unit.kill(False, iNewOwner)
 								utils.makeUnit(iUnitType, iNewOwner, tPlot, 1)
-								i = i - 1
 
 	def createAdditionalUnits(self, iCiv, tPlot):
 		if iCiv == iIndia:
@@ -2377,7 +2369,7 @@ class RiseAndFall:
 			utils.makeUnit(iHolkan, iCiv, tPlot, 2)
 		elif iCiv == iByzantium:
 			utils.makeUnit(iCataphract, iCiv, tPlot, 2)
-			utils.makeUnit(iHorseArcher, iCiv, tPlot, 2)   
+			utils.makeUnit(iHorseArcher, iCiv, tPlot, 2)
 		elif iCiv == iVikings:
 			utils.makeUnit(iHuscarl, iCiv, tPlot, 3)
 		elif iCiv == iArabia:
@@ -2813,7 +2805,7 @@ class RiseAndFall:
 			utils.makeUnit(iMinuteman, iCiv, tPlot, 4)
 			utils.makeUnit(iCannon, iCiv, tPlot, 2)
 			tSeaPlot = self.findSeaPlots(tPlot, 1, iCiv)
-			if tSeaPlot:  
+			if tSeaPlot:
 				utils.makeUnit(iWorkboat, iCiv, tSeaPlot, 2)
 				utils.makeUnit(iGalleon, iCiv, tSeaPlot, 2)
 				utils.makeUnit(iFrigate, iCiv, tSeaPlot, 1)

--- a/Assets/Python/StoredData.py
+++ b/Assets/Python/StoredData.py
@@ -170,7 +170,7 @@ class GameData:
 		self.iBetrayalTurns = 0
 		self.iRebelCiv = 0
 		
-		self.tTempFlippingCity = (0, 0)
+		self.lFlippingUnits = []
 		
 		self.bAlreadySwitched = False
 		self.bUnlimitedSwitching = False

--- a/Assets/Python/UniquePowers.py
+++ b/Assets/Python/UniquePowers.py
@@ -358,10 +358,9 @@ class UniquePowers:
 							if bUnitsApproaching:
 								print ("citynear", cityNear.getName(), "passed3")
 								utils.flipUnitsInCityBefore(tPlot, iMongolia, iOwnerNear)
-								data.tTempFlippingCity = tPlot
 								utils.flipCity(tPlot, 0, 0, iMongolia, [iOwnerNear])
-								utils.flipUnitsInCityAfter(data.tTempFlippingCity, iMongolia)
-								utils.cultureManager(data.tTempFlippingCity, 50, iOwnerNear, iMongolia, False, False, False)
+								utils.flipUnitsInCityAfter(tPlot, iMongolia)
+								utils.cultureManager(tPlot, 50, iOwnerNear, iMongolia, False, False, False)
 								CyInterface().addMessage(iOwnerNear, False, iDuration, CyTranslator().getText("TXT_KEY_UP_TERROR1", ()) + " " + cityNear.getName() + " " + CyTranslator().getText("TXT_KEY_UP_TERROR2", ()), "", 0, "", ColorTypes(iWhite), -1, -1, True, True)
 								CyInterface().addMessage(iMongolia, False, iDuration, CyTranslator().getText("TXT_KEY_UP_TERROR1", ()) + " " + cityNear.getName() + " " + CyTranslator().getText("TXT_KEY_UP_TERROR2", ()), "", 0, "", ColorTypes(iWhite), -1, -1, True, True)
 

--- a/Assets/Python/Victory.py
+++ b/Assets/Python/Victory.py
@@ -1917,9 +1917,10 @@ def onPeaceBrokered(iBroker, iPlayer1, iPlayer2):
 
 	# third Canadian goal: end twelve wars through diplomacy by 2000 AD
 	if iBroker == iCanada:
-		data.iCanadianPeaceDeals += 1
-		if data.iCanadianPeaceDeals >= 12:
-			win(iCanada, 2)
+		if isPossible(iCanada, 2):
+			data.iCanadianPeaceDeals += 1
+			if data.iCanadianPeaceDeals >= 12:
+				win(iCanada, 2)
 			
 def onBlockade(iPlayer, iGold):
 

--- a/CvGameCoreDLL/CvCity.cpp
+++ b/CvGameCoreDLL/CvCity.cpp
@@ -4391,7 +4391,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bObsolet
 		changeBuildingOnlyHealthyCount((GC.getBuildingInfo(eBuilding).isBuildingOnlyHealthy()) ? iChange : 0);
 
 		changeCultureGreatPeopleRateModifier(GC.getBuildingInfo(eBuilding).getCultureGreatPeopleRateModifier());
-		changeCultureHappiness(GC.getBuildingInfo(eBuilding).getCultureHappiness());
+		changeCultureHappiness(GC.getBuildingInfo(eBuilding).getCultureHappiness() * iChange);
 		changeCultureTradeRouteModifier(GC.getBuildingInfo(eBuilding).getCultureTradeRouteModifier());
 
 		for (iI = 0; iI < NUM_YIELD_TYPES; iI++)


### PR DESCRIPTION
Reversed looping over units. See the changes in plague.py for example

Rewrote the flipUnitsInCityBefore(), flipUnitsInCityAfter() and flipUnitsInArea() functions. It doesn't temporarily places units on (0, 67) anymore.

Deleted tTempFlippingCity from the StoredData. Temporarily saving the value is not needed.
