### PR TITLE
Fix fascist titles for Norway and Denmark

### DIFF
--- a/Assets/XML/Text/DynamicNames/DynamicNames_Vikings.xml
+++ b/Assets/XML/Text/DynamicNames/DynamicNames_Vikings.xml
@@ -158,6 +158,30 @@
 		<Spanish>National Gathering of %s1</Spanish>
 	</TEXT>
 	<TEXT>
+		<Tag>TXT_KEY_CIV_NORWAY_FASCIST</Tag>
+		<English>National Gathering of %s1</English>
+		<French>
+			<Text>Rassemblement national de %s1</Text>
+			<Gender>Male</Gender>
+			<Plural>0</Plural>
+		</French>
+		<German>National Gathering of %s1</German>
+		<Italian>National Gathering of %s1</Italian>
+		<Spanish>National Gathering of %s1</Spanish>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_CIV_DENMARK_FASCIST</Tag>
+		<English>National Gathering of %s1</English>
+		<French>
+			<Text>Rassemblement national de %s1</Text>
+			<Gender>Male</Gender>
+			<Plural>0</Plural>
+		</French>
+		<German>National Gathering of %s1</German>
+		<Italian>National Gathering of %s1</Italian>
+		<Spanish>National Gathering of %s1</Spanish>
+	</TEXT>
+	<TEXT>
 		<Tag>TXT_KEY_CIV_VIKINGS_PEOPLES</Tag>
 		<English>Norse Peoples</English>
 		<French>


### PR DESCRIPTION
## Problem
If the Short Description for Vikings changes to "Norway" or "Denmark" and Vikings becomes fascist the title of the civilization becomes "TXT_KEY_CIV_NORWAY_FASCIST" or "TXT_KEY_CIV_DENMARK_FASCIST"

## Steps to Reproduce
The Short Description changes when a Renaissance tech is researched and the capital is Oslo, Nidaros, or Roskilde, or if it is after the Renaissance and the capital is moved to one of these cities.
This can be reproduced in the 600AD start by:
 * Founding Oslo or Roskilde as the first city.
 * Researching a Renaissance technology to change from "Vikings" to "Norway" or "Denmark". Adding a Renaissance technology directly in WorldBuilder doesn't seem to work, but adding two prerequisite technologies (such as Gunpowder and Companies) and adding scientists to the city may speed it up.
 * Adding the technologies "Psychology" and "Macroeconomics" in WorldBuilder.
 * Changing player civics to "Totalitarianism" and "State Party" and NOT "Planned Economy".

## Fix
The fascist titles for Sweden and Vikings are "National Gathering of %s" (assumed to come from the [Nasjonal Samling](https://en.wikipedia.org/wiki/Nasjonal_Samling), a Norwegian party anyway), so I have simply added additional tags for "National Gathering of Denmark" and "National Gathering of Norway".