### PR TITLE
setRevealed fix

### DIFF
--- a/Assets/Python/RFCUtils.py
+++ b/Assets/Python/RFCUtils.py
@@ -483,7 +483,7 @@ def clearCatapult(iPlayer):
 		catapult.kill(False, -1)
 		
 	for plot in plots.surrounding((0, 0), radius=2):
-		plot.setRevealed(iPlayer, False, True, -1)
+		plot.setRevealed(team(iPlayer).getID(), False, False, -1)
 
 # used: Stability
 def removeReligionByArea(lPlotList, iReligion):
@@ -744,7 +744,7 @@ def getBestWorker(iPlayer):
 def completeCityFlip(tPlot, iPlayer, iOwner, iCultureChange, bBarbarianDecay = True, bBarbarianConversion = False, bAlwaysOwnPlots = False, bFlipUnits = False, bPermanentCultureChange = True):
 	plot = plot_(tPlot)
 	
-	plot.setRevealed(iPlayer, False, True, -1)
+	#plot.setRevealed(team(iPlayer).getID(), False, False, -1)
 
 	if bPermanentCultureChange:
 		cultureManager(plot, iCultureChange, iPlayer, iOwner, bBarbarianDecay, bBarbarianConversion, bAlwaysOwnPlots)
@@ -762,7 +762,7 @@ def completeCityFlip(tPlot, iPlayer, iOwner, iCultureChange, bBarbarianDecay = T
 	else:
 		createGarrisons(tPlot, iPlayer, 2)
 	
-	plot.setRevealed(iPlayer, True, True, -1)
+	plot.setRevealed(team(iPlayer).getID(), True, False, -1)
 	
 	return city(tPlot)
 	
@@ -773,7 +773,7 @@ def isNeighbor(iPlayer1, iPlayer2):
 # used: Stability
 def isGreatBuilding(iBuilding):
 	if isWorldWonderClass(infos.building(iBuilding).getBuildingClassType()):
-		return True			
+		return True
 
 	if isTeamWonderClass(infos.building(iBuilding).getBuildingClassType()):
 		return True

--- a/Assets/Python/RiseAndFall.py
+++ b/Assets/Python/RiseAndFall.py
@@ -463,7 +463,7 @@ class RiseAndFall:
 		
 		# reset map visibility
 		for plot in plots.all():
-			plot.setRevealed(iPlayer, False, True, -1)
+			plot.setRevealed(team(iPlayer).getID(), False, False, -1)
 		
 		# assign new leader
 		if iCiv in dRebirthLeaders:
@@ -808,7 +808,7 @@ class RiseAndFall:
 				
 		# Leoreth: reveal all normal plots on spawn
 		for plot in plots.normal(iCiv):
-			plot.setRevealed(iPlayer, True, True, 0)
+			plot.setRevealed(team(iPlayer).getID(), True, False, -1)
 				
 		# Leoreth: conditional state religion for colonial civs and Byzantium
 		if iCiv in [iByzantium, iArgentina, iBrazil]:
@@ -977,7 +977,7 @@ class RiseAndFall:
 				
 				#cover plots revealed
 				for plot in plots.surrounding((0, 0), radius=2):
-					plot.setRevealed(iPlayer, False, True, -1)
+					plot.setRevealed(team(iPlayer).getID(), False, False, -1)
 
 				self.createStartingUnits(iPlayer, tCapital)
 


### PR DESCRIPTION
The 1st argument should be a teamID instead of a playerID. Right now they are the same, but I'm not sure if that is still the case when the decoupling is fully implemented.

The 3rd argument is bIgnoreTerrain. I set it to false, which causes the revealed improvement type, revealed route type and reveald owner to also update.