### PR TITLE
Make Americas more reachable for normans

### DIFF
--- a/PrivateMaps/RFC_Earth.txt
+++ b/PrivateMaps/RFC_Earth.txt
@@ -18329,7 +18329,7 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=40,y=68
-	TerrainType=TERRAIN_OCEAN
+	TerrainType=TERRAIN_ARCTIC_COAST
 	PlotType=3
 EndPlot
 BeginPlot
@@ -18345,7 +18345,6 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=40,y=71
-	BonusType=BONUS_WHALE
 	TerrainType=TERRAIN_ARCTIC_COAST
 	PlotType=3
 EndPlot
@@ -18790,6 +18789,7 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=41,y=69
+	BonusType=BONUS_WHALE
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
 EndPlot
@@ -22228,6 +22228,7 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=49,y=74
+	BonusType=BONUS_WHALE
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
 EndPlot
@@ -22628,7 +22629,6 @@ BeginPlot
 EndPlot
 BeginPlot
 	x=50,y=73
-	BonusType=BONUS_WHALE
 	TerrainType=TERRAIN_OCEAN
 	PlotType=3
 EndPlot


### PR DESCRIPTION
Have been playing norse recently. Currently historical victory is not really beatable since you have to make a lot of culture in both Iceland and Greenland to claim ocean tiles around. This is very rng dependent since there is no direct control over which tile is claimed next, hard to do within 50 turns (which is the time goal expires). And also this is not immersive at all since creating Babylon-ish level of culture in Northern Atlantic to beat the game seams stupid.

Whales were moved in Iceland and Greenland to more appropriate spots. Now right tiles are attached to the cities first, which allows you to colonize Greenland after first cultural expansion in Iceland, and then colonize America after first cultural expansion in Greenland.

Playtested it a bit and I have managed to complete this goal by turn 45 (and it is most probably possible to do that a bit earlier)