### PR TITLE
BUGFIX: wrong cores and capitals returned

### DIFF
--- a/Assets/Python/Core.py
+++ b/Assets/Python/Core.py
@@ -1253,7 +1253,7 @@ class PlotFactory:
 		return self.core(identifier)
 
 	def core(self, identifier):
-		iPeriod = player(identifier).getPeriod()
+		iPeriod = game.getPeriod(identifier)
 		if iPeriod in dPeriodCoreArea:
 			return self.area(dPeriodCoreArea, dPeriodCoreAreaExceptions, iPeriod)
 		return self.area(dCoreArea, dCoreAreaExceptions, identifier)
@@ -1269,7 +1269,7 @@ class PlotFactory:
 		return self.birth(identifier)
 	
 	def capital(self, identifier):
-		iPeriod = player(identifier).getPeriod()
+		iPeriod = game.getPeriod(identifier);
 		if iPeriod in dPeriodCapitals:
 			return plot(dPeriodCapitals[iPeriod])
 		return plot(dCapitals[identifier])


### PR DESCRIPTION
To reproduce the bug before this commit:
1) start 600AD scenario as Norse
2) In python console from Core import *
3) In python console print plots.capital(11) (11 is Celts)

Should return cords of Dublin, but instead returns cords of Paris since player.getPeriod() method always returns -1 instead of set period