### PR TITLE
Fix use after free crash bug in colonialAcquisition

### DIFF
--- a/Assets/Python/RFCUtils.py
+++ b/Assets/Python/RFCUtils.py
@@ -355,7 +355,7 @@ def colonialAcquisition(iPlayer, tPlot):
 	if plot.getOwner() >= 0 and not is_minor(plot.getOwner()) and team(player(iPlayer).getTeam()).canChangeWarPeace(plot.getTeam()):
 		player(iPlayer).forcePeace(plot.getOwner())
 		
-	makeUnits(iPlayer, iWorker, tPlot, iNumUnits)
+	makeUnits(iPlayer, iWorker, plot, iNumUnits)
 	createRoleUnit(iPlayer, plot, iAttack, iNumUnits)
 		
 	iMissionary = missionary(player(iPlayer).getStateReligion())


### PR DESCRIPTION
### Description
Fixes a use after free bug on a `CyCity` in `colonialAcquisition`.

### Cause
When `colonialAcquisition` is run on a plot with a city the game suffers a null pointer crash.

`colonialAcquisition`  receives the city plot as `tPlot`. `flipCity` is then called which frees the underlying `CvCity`. Finally `makeUnits` is called to spawn some workers which can cause a crash if the memory has been reused at that point.

```py
def colonialAcquisition(iPlayer, tPlot):
	...
	plot = plot_(tPlot)
	if plot.isCity():
		flipCity(plot, False, True, iPlayer)      # <-- tPlot underlying CvCity is freed here
	else:
	...
	makeUnits(iPlayer, iWorker, tPlot, iNumUnits) # <-- tPlot used after free
```

### Notes
I got this bug on 4e8e138efb411d59f00cf8cc2c1f74c22b32ecd1, but I have checked that it appears and works also on the latest commit on develop (617c9b940d9e74ee1be9a40de22e198936d2f794).

I have a save game where the bug happens after pressing end turn, let me know if you want it for checking (I don't seem to be able to attach it to this pull request).