### PR TITLE
Improve performance of CvGame::setUpdatePlotGroups by only updating plots with a flag set

### DIFF
--- a/CvGameCoreDLL/CvGame.cpp
+++ b/CvGameCoreDLL/CvGame.cpp
@@ -10953,7 +10953,11 @@ void CvGame::setUpdatePlotGroups(bool bNewValue)
 	{
 		for (int iI = 0; iI < GC.getMap().numPlots(); iI++)
 		{
-			GC.getMap().plotByIndex(iI)->updatePlotGroup();
+			CvPlot *plot = GC.getMap().plotByIndex(iI);
+			if (plot->shouldUpdatePlotGroup())
+			{
+				plot->updatePlotGroup();
+			}
 		}
 	}
 }

--- a/CvGameCoreDLL/CvPlot.cpp
+++ b/CvGameCoreDLL/CvPlot.cpp
@@ -7892,7 +7892,10 @@ void CvPlot::updatePlotGroup()
 void CvPlot::updatePlotGroup(PlayerTypes ePlayer, bool bRecalculate)
 {
 	if (!GC.getGameINLINE().isUpdatePlotGroups())
+	{
+		m_bShouldUpdatePlotGroup = true;
 		return;
+	}
 
 	PROFILE("CvPlot::updatePlotGroup(Player)");
 
@@ -7992,6 +7995,14 @@ void CvPlot::updatePlotGroup(PlayerTypes ePlayer, bool bRecalculate)
 			GET_PLAYER(ePlayer).initPlotGroup(this);
 		}
 	}
+
+	m_bShouldUpdatePlotGroup = false;
+}
+
+
+bool CvPlot::shouldUpdatePlotGroup() const
+{
+	return m_bShouldUpdatePlotGroup;
 }
 
 

--- a/CvGameCoreDLL/CvPlot.h
+++ b/CvGameCoreDLL/CvPlot.h
@@ -411,6 +411,7 @@ public:
 	void setPlotGroup(PlayerTypes ePlayer, CvPlotGroup* pNewValue);
 	void updatePlotGroup();
 	void updatePlotGroup(PlayerTypes ePlayer, bool bRecalculate = true);
+	bool shouldUpdatePlotGroup(void) const;
 
 	int getVisibilityCount(TeamTypes eTeam) const;																											// Exposed to Python
 	void changeVisibilityCount(TeamTypes eTeam, int iChange, InvisibleTypes eSeeInvisible, bool bUpdatePlotGroups);							// Exposed to Python
@@ -631,6 +632,8 @@ protected:
 	bool m_bFlagDirty:1;
 	bool m_bPlotLayoutDirty:1;
 	bool m_bLayoutStateWorked:1;
+
+	bool m_bShouldUpdatePlotGroup:1;
 
 	char /*PlayerTypes*/ m_eOwner;
 	CivilizationTypes m_eCultureConversionCivilization;


### PR DESCRIPTION
### Description
This is an attempt to improve performance at end of turn when `CvGame::setUpdatePlotGroups()` is called. It is related to recent discussions in the "Bug Reports and Technical Issues" thread on civfanatics.com.

`CvGame::setUpdatePlotGroups()` takes a long time running through all of the plots in the map when `bNewValue` is `true`. I verified this by doing some simple timings in the code using the >20min America save linked in the thread (https://forums.civfanatics.com/threads/bug-reports-and-technical-issues.533867/post-16969667) I measured two calls to `CvGame::setUpdatePlotGroups` taking approximately 17 and 5 minutes on my computer.

### Fix
Added a `m_shouldUpdatePlotGroup` flag to `CvPlot` which is set to `true` when `updatePlotGroup()` is called and `m_bUpdatePlotGroups` is set to `false` in `CvGame`. Call it a "dirty bit".

Later when `CvGame::setUpdatePlotGroups()` is called with `bNewValue` it checks the `m_shouldUpdatePlotGroup` and only calls `updatePlotGroup` on the plots that have the flag set.

After this change both of the America saves linked in the thread take <1 min to complete on my computer.

### Misc
The flag is set to `false` at the end of `CvPlot::updatePlotGroup(PlayerTypes ePlayer, bool bRecalculate)`. Maybe this should be done in `CvGame::setUpdatePlotGroups()`?

Also not sure if the naming of the functions/variables are good.

I'm not very familiar with this code base, so I don't know if these changes have any unintended consequences.