### PR TITLE
Fix use after free bug in CvCity::kill

### DIFF
--- a/Assets/Python/Rise.py
+++ b/Assets/Python/Rise.py
@@ -703,9 +703,10 @@ class Birth(object):
 					capital = completeCityFlip(city, self.iPlayer, city.getOwner(), 100)
 				else:
 					self.data.lPreservedWonders += [iWonder for iWonder in infos.buildings() if isWonder(iWonder) and city.isHasRealBuilding(iWonder)]
-				
-					plot_(city).eraseAIDevelopment()
-					plot_(city).setImprovementType(iCityRuins)
+
+					cityPlot = plot_(city)
+					cityPlot.eraseAIDevelopment()
+					cityPlot.setImprovementType(iCityRuins)
 		
 		if capital:
 			self.prepareCity(capital)

--- a/CvGameCoreDLL/CvCity.cpp
+++ b/CvGameCoreDLL/CvCity.cpp
@@ -1109,8 +1109,8 @@ void CvCity::kill(bool bUpdatePlotGroups)
 
 	CvEventReporter::getInstance().cityLost(this);
 
-	GET_PLAYER(getOwnerINLINE()).deleteCity(getID());
-	GET_PLAYER(getOwnerINLINE()).updateCultureRanks();
+	GET_PLAYER(eOwner).deleteCity(getID());
+	GET_PLAYER(eOwner).updateCultureRanks();
 
 	pPlot->updateCulture(true, false);
 

--- a/CvGameCoreDLL/CvPlayer.cpp
+++ b/CvGameCoreDLL/CvPlayer.cpp
@@ -5336,10 +5336,12 @@ void CvPlayer::disband(CvCity* pCity)
 
 	GC.getGameINLINE().addDestroyedCityName(pCity->getName());
 
+	PlayerTypes eOwner = pCity->getOwnerINLINE();
+
 	pCity->kill(true);
 
 	// Leoreth
-	GET_PLAYER(pCity->getOwnerINLINE()).updateMaintenance();
+	GET_PLAYER(eOwner).updateMaintenance();
 }
 
 


### PR DESCRIPTION
### Bug
`CvCity::kill` calls `CvPlayer::deleteCity` which removes the `CvCity` from a list in the `CvPlayer`, but also calls delete on this `CvCity`. When `getOwnerINLINE()` is called after that it can return some bogus value if the memory has been overwritten.

```cpp
void CvCity::kill(bool bUpdatePlotGroups)
{
 	...
	GET_PLAYER(getOwnerINLINE()).deleteCity(getID());  // <-- this is deleted here
	GET_PLAYER(getOwnerINLINE()).updateCultureRanks(); // getOwner() then used on deleted CvCity
	...
```

### Fix
Use the `eOwner` value which was set `eOwner = getOwnerINLINE()` earlier in the function.

### Misc
I have a save where this causes a crash for me on end turn. Let me know if you need it.